### PR TITLE
Adjusted constants and fixed tests around weights and fees

### DIFF
--- a/runtime/arctic/src/constants.rs
+++ b/runtime/arctic/src/constants.rs
@@ -1,9 +1,8 @@
 pub mod currency {
 	use crate::Balance;
-	use frame_support::weights::constants::{ExtrinsicBaseWeight, WEIGHT_PER_SECOND};
 
 	/// The existential deposit.
-	pub const EXISTENTIAL_DEPOSIT: Balance = 1_000_000;
+	pub const EXISTENTIAL_DEPOSIT: Balance = 1 * CENTS;
 
 	pub const UNITS: Balance = 1_000_000_000_000_000_000; // 1.0 ICY = 10e18 Planck
 	pub const DOLLARS: Balance = UNITS;
@@ -16,20 +15,7 @@ pub mod currency {
 	pub const ICY: Balance = UNITS;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 10 * CENTS + (bytes as Balance) * 10 * MILLICENTS
-	}
-
-	fn base_tx_fee() -> Balance {
-		CENTS / 10
-	}
-
-	// 1 KSM = 10 DOT
-	// DOT precision is 1/100 of KSM and BNC
-	pub fn dot_per_second() -> u128 {
-		let base_weight = Balance::from(ExtrinsicBaseWeight::get());
-		let base_tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;
-		let fee_per_second = base_tx_per_second * base_tx_fee();
-		fee_per_second / 100 * 10 / 100
+		items as Balance * 1 * DOLLARS + (bytes as Balance) * 5 * MILLICENTS
 	}
 }
 
@@ -78,8 +64,8 @@ pub mod fee {
 	impl WeightToFeePolynomial for WeightToFee {
 		type Balance = Balance;
 		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-			// extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT (reference Kusama fee)
-			let p = super::currency::MILLICENTS;
+			// in Arctic, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
+			let p = super::currency::CENTS;
 			let q = 10 * Balance::from(ExtrinsicBaseWeight::get());
 			smallvec![WeightToFeeCoefficient {
 				degree: 1,

--- a/runtime/arctic/src/impls.rs
+++ b/runtime/arctic/src/impls.rs
@@ -79,21 +79,21 @@ mod tests {
 			<Runtime as pallet_transaction_payment::Config>::WeightToFee::weight_to_fee(
 				&max_block_weight,
 			);
-		assert_eq!(full_block, 16000000000000000); // 0.16 ICY
 
-		//assert!(full_block >= 1_000 * MILLICENTS);
-		//assert!(full_block <= 10_000 * CENTS);
+		assert!(full_block >= 10 * DOLLARS);
+		assert!(full_block <= 100 * DOLLARS);
 	}
 
 	#[test]
-	fn base_fee_is_within_bounds() {
+	fn base_fee_is_correct() {
 		let extrinsic_base_weight = frame_support::weights::constants::ExtrinsicBaseWeight::get();
+
 		let x: u128 = <Runtime as pallet_transaction_payment::Config>::WeightToFee::weight_to_fee(
 			&extrinsic_base_weight,
 		);
+
 		let y = CENTS / 10;
-		assert_eq!(x.max(y) - x.min(y), 999000000000000);
-		assert!(x.max(y) - x.min(y) < CENTS);
+		assert!(x.max(y) - x.min(y) < MILLICENTS);
 	}
 
 	fn max_normal() -> Weight {

--- a/runtime/arctic/src/lib.rs
+++ b/runtime/arctic/src/lib.rs
@@ -393,7 +393,7 @@ impl pallet_authorship::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u128 = currency::EXISTENTIAL_DEPOSIT; // 0.0001 ICY
+	pub const ExistentialDeposit: u128 = currency::EXISTENTIAL_DEPOSIT; // 0.01 ICY
 	// For weight estimation, we assume that the most locks on an individual account will be 50.
 	// This number may need to be adjusted in the future if this assumption no longer holds true.
 	pub const MaxLocks: u32 = 50;
@@ -417,8 +417,8 @@ parameter_types! {
 	pub const TransactionByteFee: Balance = 10 * currency::MILLICENTS;
 	pub const OperationalFeeMultiplier: u8 = 5;
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
-	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_000u128);
+	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 100_000);
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
 }
 
 pub type WeightToFee = constants::fee::WeightToFee;

--- a/runtime/frost/src/constants.rs
+++ b/runtime/frost/src/constants.rs
@@ -2,7 +2,7 @@ pub mod currency {
 	use crate::Balance;
 
 	/// The existential deposit.
-	pub const EXISTENTIAL_DEPOSIT: Balance = 1_000_000;
+	pub const EXISTENTIAL_DEPOSIT: Balance = 1 * CENTS;
 
 	pub const UNITS: Balance = 1_000_000_000_000_000_000; // 1.0 ICY = 10e18 Planck
 	pub const DOLLARS: Balance = UNITS;
@@ -15,7 +15,7 @@ pub mod currency {
 	pub const ICY: Balance = UNITS;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 10 * CENTS + (bytes as Balance) * 10 * MILLICENTS
+		items as Balance * 1 * DOLLARS + (bytes as Balance) * 5 * MILLICENTS
 	}
 }
 
@@ -64,8 +64,8 @@ pub mod fee {
 	impl WeightToFeePolynomial for WeightToFee {
 		type Balance = Balance;
 		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-			// extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT (reference Kusama fee)
-			let p = super::currency::MILLICENTS;
+			// in Frost, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
+			let p = super::currency::CENTS;
 			let q = 10 * Balance::from(ExtrinsicBaseWeight::get());
 			smallvec![WeightToFeeCoefficient {
 				degree: 1,

--- a/runtime/frost/src/impls.rs
+++ b/runtime/frost/src/impls.rs
@@ -72,30 +72,28 @@ mod tests {
 	}
 
 	#[test]
-	#[ignore]
-	// Test that the fee for `MAXIMUM_BLOCK_WEIGHT` of weight has sane bounds.
 	fn full_block_fee_is_correct() {
 		let max_block_weight = RuntimeBlockWeights::get().max_block;
 
-		let full_block =
+		let full_block: u128 =
 			<Runtime as pallet_transaction_payment::Config>::WeightToFee::weight_to_fee(
 				&max_block_weight,
 			);
-		assert_eq!(full_block, 16000000000000000); // 0.16 ICY
 
-		//assert!(full_block >= 1_000 * MILLICENTS);
-		//assert!(full_block <= 10_000 * CENTS);
+		assert!(full_block >= 10 * DOLLARS);
+		assert!(full_block <= 100 * DOLLARS);
 	}
 
 	#[test]
-	fn base_fee_is_within_bounds() {
+	fn base_fee_is_correct() {
 		let extrinsic_base_weight = frame_support::weights::constants::ExtrinsicBaseWeight::get();
+
 		let x: u128 = <Runtime as pallet_transaction_payment::Config>::WeightToFee::weight_to_fee(
 			&extrinsic_base_weight,
 		);
+
 		let y = CENTS / 10;
-		assert_eq!(x.max(y) - x.min(y), 999000000000000);
-		assert!(x.max(y) - x.min(y) < CENTS);
+		assert!(x.max(y) - x.min(y) < MILLICENTS);
 	}
 
 	fn max_normal() -> Weight {

--- a/runtime/frost/src/lib.rs
+++ b/runtime/frost/src/lib.rs
@@ -316,7 +316,7 @@ impl pallet_timestamp::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u128 = currency::EXISTENTIAL_DEPOSIT; // 0.0001 ICY
+	pub const ExistentialDeposit: u128 = currency::EXISTENTIAL_DEPOSIT; // 0.01 ICY
 	// For weight estimation, we assume that the most locks on an individual account will be 50.
 	// This number may need to be adjusted in the future if this assumption no longer holds true.
 	pub const MaxLocks: u32 = 50;
@@ -365,8 +365,8 @@ parameter_types! {
 	pub const TransactionByteFee: Balance = 10 * currency::MILLICENTS;
 	pub const OperationalFeeMultiplier: u8 = 5;
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
-	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_000u128);
+	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 100_000);
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
 }
 
 impl pallet_transaction_payment::Config for Runtime {


### PR DESCRIPTION
Changed Existential deposit to 1 * CENTS. The idea is to allow the any account to have at least tokens to pay the fees for a few transfers.

Transfer fee estimation: 0.0018 ICY. Is still around 10 times lower than Rococo and Westend.

Updated the coefficients for WeightToFeePolynomial. The way the weightToFee is calculated is:

weightToFee(weight) = c * weight, where c is a constant, such as c * base_extrinsic_fee is 1/10 CENTS.

Corrected Failing tests around fee bounds.

Increased AdjustmentVariable with 3x and MinimumMultiplier with 1_000x in order to speed up the increase in Fee when the Network is busy.

The way the adjusted fee is calculated is:

AdjustedFee(multiplier, unadjusted_fee) = multiplier * unadjusted_fee. The multiplier starts with the minimum and is updated at the end of each block. If the block is more than 25% full (block weight execution greater than 0.5s) than the multiplier will increase for the next block. The value it increases is dependent of the AdjustmentVariable.

