### PR TITLE
bring Airdrop pallet to ice-node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,6 +3062,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "log",
+ "pallet-airdrop",
  "pallet-assets",
  "pallet-aura",
  "pallet-authorship",
@@ -5593,6 +5594,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "pallet-airdrop"
+version = "0.4.3"
+dependencies = [
+ "fp-evm",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "hex",
+ "hex-literal",
+ "log",
+ "pallet-balances",
+ "pallet-evm-precompile-sha3fips",
+ "pallet-evm-precompile-simple",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "pallet-airdrop",
  "pallet-assets",
  "pallet-aura",
  "pallet-authorship",

--- a/node/src/chain_spec/arctic.rs
+++ b/node/src/chain_spec/arctic.rs
@@ -3,7 +3,7 @@ use arctic_runtime::currency::ICY;
 use arctic_runtime::{
 	wasm_binary_unwrap, AccountId, AuraConfig, AuraId, BalancesConfig, CollatorSelectionConfig,
 	CouncilConfig, EVMConfig, GenesisConfig, ParachainInfoConfig, SessionConfig, SessionKeys,
-	Signature, SudoConfig, SystemConfig, VestingConfig, TechnicalCommitteeConfig,
+	Signature, SudoConfig, SystemConfig, VestingConfig, TechnicalCommitteeConfig, AirdropConfig,
 };
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
@@ -22,6 +22,9 @@ const ARCTIC_PROPERTIES: &str = r#"
             "tokenDecimals": 18,
             "tokenSymbol": "ICZ"
         }"#;
+
+const AIRDROP_MERKLE_ROOT: [u8; 32] =
+	hex_literal::hex!("990e01e3959627d2ddd94927e1c605a422b62dc3b8c8b98d713ae6833c3ef122");
 
 /// Gen Arctic chain specification for given parachain id.
 pub fn get_chain_spec(para_id: u32) -> ArcticChainSpec {
@@ -61,6 +64,8 @@ pub fn get_chain_spec(para_id: u32) -> ArcticChainSpec {
 				],
 				// Sudo account
 				hex!["62687296bffd79f12178c4278b9439d5eeb8ed7cc0b1f2ae29307e806a019659"].into(),
+				// Airdrop creditor account
+				hex!["10b3ae7ebb7d722c8e8d0d6bf421f6d5dbde8d329f7c905a201539c635d61872"].into(),
 				para_id.into(),
 			)
 		},
@@ -110,6 +115,8 @@ pub fn get_dev_chain_spec(para_id: u32) -> ArcticChainSpec {
 				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
 				// Sudo account
 				sudo_key.clone(),
+				// Airdrop creditor account
+				hex!("10b3ae7ebb7d722c8e8d0d6bf421f6d5dbde8d329f7c905a201539c635d61872").into(),
 				para_id.into(),
 			)
 		},
@@ -138,6 +145,7 @@ fn make_genesis(
 	council_members: Vec<AccountId>,
 	technical_committee: Vec<AccountId>,
 	root_key: AccountId,
+	airdrop_creditor_account: [u8; 32],
 	parachain_id: ParaId,
 ) -> GenesisConfig {
 	GenesisConfig {
@@ -191,6 +199,10 @@ fn make_genesis(
 		parachain_system: Default::default(),
 		simple_inflation: Default::default(),
 		fees_split: Default::default(),
+		airdrop: AirdropConfig {
+			creditor_account: sp_runtime::AccountId32::new(airdrop_creditor_account),
+			merkle_root: AIRDROP_MERKLE_ROOT,
+		},
 	}
 }
 

--- a/node/src/chain_spec/frost.rs
+++ b/node/src/chain_spec/frost.rs
@@ -1,7 +1,7 @@
 use frost_runtime::{
 	currency::ICY, opaque::SessionKeys, AccountId, AuraConfig, BalancesConfig, CouncilConfig,
 	EVMConfig, EthereumConfig, GenesisConfig, GrandpaConfig, SessionConfig, Signature, SudoConfig,
-	SystemConfig, TreasuryPalletId, WASM_BINARY,
+	SystemConfig, TreasuryPalletId, WASM_BINARY, AirdropConfig,
 };
 use hex_literal::hex;
 use sc_service::ChainType;
@@ -46,6 +46,9 @@ pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
 	(get_from_seed::<AuraId>(s), get_from_seed::<GrandpaId>(s))
 }
 
+const AIRDROP_MERKLE_ROOT: [u8; 32] =
+	hex_literal::hex!("990e01e3959627d2ddd94927e1c605a422b62dc3b8c8b98d713ae6833c3ef122");
+
 /// Initialize frost testnet configuration
 pub fn testnet_config() -> Result<FrostChainSpec, String> {
 	let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
@@ -82,6 +85,8 @@ pub fn testnet_config() -> Result<FrostChainSpec, String> {
 				],
 				// Sudo account
 				hex!["62687296bffd79f12178c4278b9439d5eeb8ed7cc0b1f2ae29307e806a019659"].into(),
+				// Airdrop creditor account
+				hex!("10b3ae7ebb7d722c8e8d0d6bf421f6d5dbde8d329f7c905a201539c635d61872").into(),
 				// Pre-funded accounts
 				vec![
 					TreasuryPalletId::get().into_account_truncating(),
@@ -124,6 +129,8 @@ pub fn development_config() -> Result<FrostChainSpec, String> {
 				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
 				// Sudo account
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				// Airdrop creditor account
+				hex!("10b3ae7ebb7d722c8e8d0d6bf421f6d5dbde8d329f7c905a201539c635d61872").into(),
 				// Pre-funded accounts
 				vec![
 					TreasuryPalletId::get().into_account_truncating(),
@@ -171,6 +178,8 @@ pub fn local_testnet_config() -> Result<FrostChainSpec, String> {
 				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
 				// Sudo account
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				// Airdrop creditor account
+				hex!("10b3ae7ebb7d722c8e8d0d6bf421f6d5dbde8d329f7c905a201539c635d61872").into(),
 				// Pre-funded accounts
 				vec![
 					get_account_id_from_seed::<sr25519::Public>("Alice"),
@@ -214,6 +223,7 @@ fn testnet_genesis(
 	_initial_authorities: Vec<(AuraId, GrandpaId)>,
 	council_members: Vec<AccountId>,
 	root_key: AccountId,
+	airdrop_creditor_account: [u8; 32],
 	endowed_accounts: Vec<AccountId>,
 	_enable_println: bool,
 ) -> GenesisConfig {
@@ -278,5 +288,9 @@ fn testnet_genesis(
 		treasury: Default::default(),
 		simple_inflation: Default::default(),
 		fees_split: Default::default(),
+		airdrop: AirdropConfig {
+			creditor_account: sp_runtime::AccountId32::new(airdrop_creditor_account),
+			merkle_root: AIRDROP_MERKLE_ROOT,
+		},
 	}
 }

--- a/pallets/airdrop/Cargo.toml
+++ b/pallets/airdrop/Cargo.toml
@@ -1,0 +1,71 @@
+[package]
+name = "pallet-airdrop"
+version = "0.4.3"
+edition = "2021"
+description = "Handle intiial airdropping"
+authors = ["ICONOSphere <social@iconosphere.io>"]
+license = "Unlicense"
+publish = false
+repository = "https://github.com/ibriz/ice-substrate.git"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+log = { version = "0.4.14", default-features = false }
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+hex-literal = { version = "0.3.4" }
+codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2.1.0", default-features = false, features = [
+    "derive",
+] }
+serde = { version = '1.0', default-features = false, features = ['derive'] }
+serde_json = { version = '1.0', default-features = false, features = ['alloc'] }
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+sp-core = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+pallet-vesting = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+
+pallet-evm-precompile-sha3fips = { default-features = false, git = "https://github.com/web3labs/frontier", branch = "polkadot-v0.9.23" }
+pallet-evm-precompile-simple = { default-features = false, git = "https://github.com/web3labs/frontier", branch = "polkadot-v0.9.23" }
+fp-evm = { default-features = false, git = "https://github.com/web3labs/frontier", branch = "polkadot-v0.9.23"}
+
+[dev-dependencies]
+sp-core = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+
+[features]
+no-vesting = []
+default = ["std"]
+std = [
+    "log/std",
+    "codec/std",
+    "hex/std",
+    "scale-info/std",
+    "serde/std",
+    "frame-support/std",
+    "frame-system/std",
+    "frame-benchmarking/std",
+
+    "sp-runtime/std",
+    "sp-io/std",
+    "sp-std/std",
+    "sp-core/std",
+    "pallet-balances/std",
+    "pallet-vesting/std",
+
+    "pallet-evm-precompile-sha3fips/std",
+    "pallet-evm-precompile-simple/std",
+    "fp-evm/std",
+]
+
+runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
+try-runtime = ["frame-support/try-runtime"]

--- a/pallets/airdrop/src/benchmarking.rs
+++ b/pallets/airdrop/src/benchmarking.rs
@@ -1,0 +1,294 @@
+//! Benchmarking setup for pallet-airdrop
+
+use super::*;
+
+use crate as pallet_airdrop;
+#[allow(unused)]
+use crate::Pallet;
+use codec::Decode;
+use frame_benchmarking::{account, benchmarks, whitelisted_caller};
+use frame_support::{pallet_prelude::*, traits::ConstU32, BoundedVec};
+use frame_system::RawOrigin;
+use sp_core::sr25519;
+use sp_core::*;
+use sp_runtime::traits::Convert;
+use sp_runtime::traits::IdentifyAccount;
+use sp_runtime::traits::Saturating;
+use sp_std::prelude::*;
+use types::{AccountIdOf, BlockNumberOf, IceAddress, MerkleHash, RawPayload};
+
+#[derive(Clone, Debug)]
+pub struct BenchmarkSample<'a> {
+	pub icon_address: &'a str,
+	pub ice_address: &'a str,
+	pub message: &'a str,
+	pub icon_signature: &'a str,
+	pub ice_signature: &'a str,
+	pub amount: u128,
+	pub defi_user: bool,
+	pub merkle_proofs: &'a [&'a str],
+	pub merkle_root: &'a str,
+}
+
+#[derive(Clone, Debug)]
+pub struct UserClaimTestCase<T: Get<u32>> {
+	pub icon_address: types::IconAddress,
+	pub ice_address: IceAddress,
+	pub message: RawPayload,
+	pub icon_signature: types::IconSignature,
+	pub ice_signature: types::IceSignature,
+	pub amount: u128,
+	pub defi_user: bool,
+	pub merkle_proofs: BoundedVec<MerkleHash, T>,
+	pub merkle_root: [u8; 32],
+}
+
+impl<'a, B> From<BenchmarkSample<'a>> for UserClaimTestCase<B>
+where
+	B: Get<u32>,
+{
+	fn from(sample: BenchmarkSample<'a>) -> Self {
+		let proff_size = B::get();
+
+		// assert_eq!(sample.merkle_proofs.len(), proff_size as usize);
+		let amount = sample.amount;
+		let defi_user = sample.defi_user;
+		let ice_address = hex::decode(sample.ice_address).unwrap().try_into().unwrap();
+		let merkle_root = hex::decode(sample.merkle_root).unwrap().try_into().unwrap();
+		let message = sample.message.as_bytes().to_vec().try_into().unwrap();
+		let icon_address = hex::decode(sample.icon_address)
+			.unwrap()
+			.try_into()
+			.unwrap();
+		let icon_signature = hex::decode(sample.icon_signature)
+			.unwrap()
+			.try_into()
+			.unwrap();
+		let ice_signature = hex::decode(sample.ice_signature)
+			.unwrap()
+			.try_into()
+			.unwrap();
+		let merkle_proofs = sample
+			.merkle_proofs
+			.iter()
+			.map(|proff| {
+				let proff = hex::decode(proff).unwrap();
+				proff.try_into().unwrap()
+			})
+			.collect::<Vec<MerkleHash>>()
+			.try_into()
+			.unwrap();
+
+		UserClaimTestCase::<B> {
+			icon_address,
+			ice_address,
+			message,
+			merkle_root,
+			icon_signature,
+			ice_signature,
+			amount,
+			defi_user,
+			merkle_proofs,
+		}
+	}
+}
+
+pub const benchmark_samples: [BenchmarkSample; 4] = [
+	   BenchmarkSample{
+		icon_address : "3d16047c23cc3e27e807f6cfc55fb8d950555690",
+		icon_signature : "a9b435d7720228efd12327a3551ffab56e737be8071673cfdad59f25a9d20f425b99874ac4c17b29063160d247c95cc0a71b3647e58b5dfb67c1839943920b9700",
+		message : "icx_sendTransaction.data.{method.transfer.params.{wallet.9e1d877d67c30235bc90e0ff469d0f8c2b4d7df3d8efed7873715cd9da073f2f}}.dataType.call.from.hx3d16047c23cc3e27e807f6cfc55fb8d950555690.nid.0x1.nonce.0x1.stepLimit.0x0.timestamp.0x0.to.hx3d16047c23cc3e27e807f6cfc55fb8d950555690.version.0x3",
+		ice_address : "9e1d877d67c30235bc90e0ff469d0f8c2b4d7df3d8efed7873715cd9da073f2f",
+		ice_signature : "2425488fc058d9e2810ebda2e6a1466ac1f159f0db8b807037132759257131602378cba5d65859be2e3a44e5d6da91bad14dd0ead745ea159551fa748e8f1285",
+		amount : 1000000000000000000,
+		defi_user : true,
+		merkle_proofs : &[
+			"e0d3b76446424001e3ed793dce6e3768d23330c44108dc1af0b6618c291bd9ea",
+			"31a8941be7278d42e60bb911e7d1ec34c20e22c97e5de8d4523b0b156552de32",
+			"09eaef8a1f8fb9a3709a155eb40abb05164b33c20089a99ac9018e8fb372e708",
+			"b7e0d8418a2aba80ce033ca7fa6ceb446b2b3a0ab4f13b89559a24938f7006e1",
+			"8313ec772d670751b1d5325513953347874381c068edfb2fce6aca1556754be5",
+			"1ab85582900d947bb1fd40fac26fc85968f0106269d2bcd94937a7c32ee98c33",
+			"dd6d9efff5004b007dcb2d5992cfdc5bc74428820ef40c66db1454a13826451b",
+			"f5df84a6499660de837b5e5bd4734cc32077a56b68c1759d9ab3de10cc532bc6"
+		],
+		merkle_root: "990e01e3959627d2ddd94927e1c605a422b62dc3b8c8b98d713ae6833c3ef122",
+
+	   },
+	   BenchmarkSample {
+		icon_address : "2ddfa6d1cdf98944a90319bbe57c10d6a3527195",
+		icon_signature : "dd0fc37634a650ee0d13f848ea3a2f62b9d80520ae5ec8faaaee662aa6170bfb4e34a735557447dd226ef4e9793a8519ee2f04fdbe6024fb29bcd4c95edcab6900",
+		message : "icx_sendTransaction.data.{method.transfer.params.{wallet.1280a5490ab78c44127424fa8f846b1e1459caf5405e17f66cc7ca642e651370}}.dataType.call.from.hx2ddfa6d1cdf98944a90319bbe57c10d6a3527195.nid.0x1.nonce.0x1.stepLimit.0x0.timestamp.0x0.to.hx2ddfa6d1cdf98944a90319bbe57c10d6a3527195.version.0x3",
+		ice_address : "1280a5490ab78c44127424fa8f846b1e1459caf5405e17f66cc7ca642e651370",
+		ice_signature : "ce9100b0ffaa9277de4898fbe5a31f64a5e43d5319674585838dd6804ac3d555560b68e10ab501ceb1f1247fb199b21e293d9f21f72f972ec70eaa6351a4df84",
+		amount : 2000000000000000000,
+		defi_user : true,
+		merkle_proofs : &[
+			"f0581f454bb54b31bb8cb7ee3b8196d438a8588835f9f15328d09b30e35aba44",
+			"76165bcd9d4384607dec75039fda663be627ad42eb722bb8681a800244241d64",
+			"46e617f4ee231a73f2bf6963eb4f044b77c956b95b20201e89fd495c600270c4",
+			"2b003ed0aa2100689bc76a0940745c7aa244f89a3cfa7a80872d6169e092067b",
+			"6045f8c48195fb8ca809b197e3605dc4767f34df0b30094645fd6f92e9063076",
+			"7ac43c63fb6b2d1576f99004881ec01dc6edc2015e972d837ab85f482f2ea318",
+			"dd6d9efff5004b007dcb2d5992cfdc5bc74428820ef40c66db1454a13826451b",
+			"f5df84a6499660de837b5e5bd4734cc32077a56b68c1759d9ab3de10cc532bc6"
+		],
+		merkle_root:"990e01e3959627d2ddd94927e1c605a422b62dc3b8c8b98d713ae6833c3ef122",
+
+	},
+	BenchmarkSample{
+		icon_address: "bf721af547f9b594b00fd675d66f267fead26078",
+		icon_signature: "6f72df8c2137f5a72cb6b7f72536c58da0fbe355c34f4eb7ea4d361e44c2846e2c29c10dd30b92d097c50f223373e4d9dc346b290d6e27077cdf9a5c84e0e01901",
+		message: "icx_sendTransaction.data.{method.transfer.params.{wallet.a2e3b45a628e579fba6398bd61b25e237ab0cdd18190127e1b75929bb190e303}}.dataType.call.from.hxbf721af547f9b594b00fd675d66f267fead26078.nid.0x1.nonce.0x1.stepLimit.0x0.timestamp.0x0.to.hxbf721af547f9b594b00fd675d66f267fead26078.version.0x3",
+		ice_address: "a2e3b45a628e579fba6398bd61b25e237ab0cdd18190127e1b75929bb190e303",
+		ice_signature: "ecf730df0b51b12257d2c2d86945b5df2ca7076ffd448d050d9819786b63dd29276a2ba4757b611bdbf5e9f51dcba6122f57a3cd95cffd1b42197a8295e2ad82",
+		amount: 3000000000000000000,
+		defi_user: true,
+		merkle_proofs: &[
+			"798f62d51e94cb89df6260d60aa48baeef1c5a99988608e9e8cd8dbd5a8cf895",
+			"e93d3837fcc639d1f9abc176e0d92237c5b0b0e500738d6e5b35e4006272c366",
+			"97d8d7ec83be95c41e4f80c27c29fe851613af01c49eb0d19b216839ffc1fd63",
+			"f81ee4d3397af15073ba83cbf5a640f98ea7fd48596876795731ce6aac6b09d0",
+			"57a0ac7ad8d609c2ffa4fc0755b4001a8d9902c8237d8912b5645aeae18f00b5",
+			"1fe97a9f0936a47663102bc1e7f462be70166ec7865ee52abb8b0f8e96ac2532",
+			"c42ffc995410faf61588017be9c7d96716dfe8d5758cc0c47faaae84131cd152",
+			"9a76bf1c50b1699066273fd5637ef2d80d507bbf19d7b41684768e92e6b0faac",
+			"16007529c0508b834034a7ec9a27026a596cc3dbbdbc817c23cdcab944f706c2",
+			"c8c790ef89aec760e0087d79668d5f25bfcfbba74865bc2f514e259f1607015b"
+		],
+		merkle_root:"990e01e3959627d2ddd94927e1c605a422b62dc3b8c8b98d713ae6833c3ef122",
+
+	},
+	BenchmarkSample{
+		icon_address : "669fe1b8d281899304a10bcc43c008b80c2a832d",
+		icon_signature : "49e476b6c8d9ea10a318a3a92b3cb2d69636c5f2717f9b7300838c9cf530f21a3436d31c96db65b7a10599c3b149df6a6759574b23b12718e7ce481c0963a61400",
+		message : "icx_sendTransaction.data.{method.transfer.params.{wallet.6ca3c5c62fe77c4c46cf9658891cf13bd4cf46ab6615273f6321701edba96c51}}.dataType.call.from.hx669fe1b8d281899304a10bcc43c008b80c2a832d.nid.0x1.nonce.0x1.stepLimit.0x0.timestamp.0x0.to.hx669fe1b8d281899304a10bcc43c008b80c2a832d.version.0x3",
+		ice_address : "6ca3c5c62fe77c4c46cf9658891cf13bd4cf46ab6615273f6321701edba96c51",
+		ice_signature : "aa1bf82922fcf897249ec77ef46b43b82f126947baebea2b20653f9b62910915d581e5ac2c134b12b515cac2e85dd1bb96573ba67311b0f711d6ca18e2e3d68a",
+		amount : 4000000000000000000,
+		defi_user : true,
+		merkle_proofs : &[
+			"4cb4baa6637f5d39eae5d3998b35a15d8ff245e006e0c3c354e1cf641bf89894",
+			"44912681ae011b28768811e9ab063f4a9988580c82f2a71122cd719f922ef3ee",
+			"bc3957fa95f3ccba5a7f626b65cd4b9f8c6512ec67dd281feea1738bb1202dc3",
+			"0c5721659c64f2c1da34d4f8cdcaa7d770860e6ad774cd9d5c9f4e4fd9d16d06",
+			"e784711156cde55af3f71429d64e31062233e3dc2f98712425e0854f3b261ccd",
+			"89ff5572284e1c8f4fdc43c9499d75addcedd53a79d4dcf79dcc3f0b48263d5c",
+			"5cd8cb26c4b08ade5da89fe0e3dce3d7a5c5d039364ebc5ae4ccf628aa7d7973",
+			"852ccbd392aef04c99b16c1441c8fa690183c635e9cd1534c21c13f4ce3d505b",
+			"348af565a5d5b2a4750c6c6fb9b272f0331eb001a70abb4d414bbd90eff2aa56",
+			"c8c790ef89aec760e0087d79668d5f25bfcfbba74865bc2f514e259f1607015b"
+		],
+		merkle_root:"990e01e3959627d2ddd94927e1c605a422b62dc3b8c8b98d713ae6833c3ef122",
+
+	}
+   ];
+
+const creditor_key: sp_core::sr25519::Public = sr25519::Public([1; 32]);
+
+fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
+	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
+}
+
+benchmarks! {
+	set_airdrop_server_account {
+				let old_account: types::AccountIdOf<T> = frame_benchmarking::whitelisted_caller();
+
+				let new_account: types::AccountIdOf<T> = frame_benchmarking::whitelisted_caller();
+
+				<ServerAccount<T>>::set(Some(old_account.clone()));
+
+			}: set_airdrop_server_account(RawOrigin::Root,new_account.clone())
+	verify {
+				assert_last_event::<T>(Event::ServerAccountChanged{
+					old_account:Some(old_account.clone()),
+					new_account:new_account.clone()
+				}.into());
+	}
+
+	update_airdrop_state {
+		let old_state= Pallet::<T>::get_airdrop_state();
+		let new_state = types::AirdropState::default();
+
+	}: update_airdrop_state(RawOrigin::Root, new_state.clone())
+	verify {
+		 assert_last_event::<T>(Event::AirdropStateUpdated {
+			old_state,
+			new_state,
+		}.into());
+	}
+
+
+	dispatch_user_claim {
+		let x in 0 .. 3;
+		let caller: types::AccountIdOf<T> = frame_benchmarking::whitelisted_caller();
+		// let ofw_account = sr25519::Public([1; 32]).into_account();
+		Pallet::<T>::set_creditor_account(creditor_key);
+		let system_account_id = Pallet::<T>::get_creditor_account().unwrap();
+		Pallet::<T>::init_balance(&system_account_id,10_000_000_000_000_000_000_000_000);
+		let case= UserClaimTestCase::<<T as pallet::Config>::MaxProofSize>::try_from(benchmark_samples[x as usize].clone()).unwrap();
+		let amount = <T::BalanceTypeConversion as Convert<_, _>>::convert(case.amount);
+		 let icon_address=case.icon_address.clone();
+		 let mut new_state = types::AirdropState::default();
+		 new_state.block_claim_request=false;
+		 new_state.block_exchange_request=false;
+		<AirdropChainState<T>>::set(new_state.clone());
+
+	}: dispatch_user_claim(
+		RawOrigin::Root,
+		case.icon_address,
+		case.ice_address,
+		case.message,
+		case.icon_signature,
+		case.ice_signature,
+		amount,
+		case.defi_user,
+		case.merkle_proofs)
+	verify {
+		assert_last_event::<T>(Event::ClaimSuccess(icon_address.clone()).into());
+	}
+
+	dispatch_exchange_claim {
+		let x in 0 .. 3;
+
+		Pallet::<T>::set_creditor_account(creditor_key);
+		let system_account_id = Pallet::<T>::get_creditor_account().unwrap();
+		Pallet::<T>::init_balance(&system_account_id,10_000_000_000_000_000_000_000_000);
+		let case= UserClaimTestCase::<<T as pallet::Config>::MaxProofSize>::try_from(benchmark_samples[x as usize].clone()).unwrap();
+		let amount = <T::BalanceTypeConversion as Convert<_, _>>::convert(case.amount);
+		let icon_address=case.icon_address.clone();
+		<ExchangeAccountsMap<T>>::insert(icon_address.clone(),amount);
+		let mut new_state = types::AirdropState::default();
+		new_state.block_claim_request=false;
+		new_state.block_exchange_request=false;
+		<AirdropChainState<T>>::set(new_state.clone());
+
+
+	}: dispatch_exchange_claim(
+		RawOrigin::Root,
+		icon_address.clone(),
+		case.ice_address,
+		amount,
+		case.defi_user,
+		case.merkle_proofs)
+	verify {
+		assert_last_event::<T>(Event::ClaimSuccess(icon_address.clone()).into());
+	}
+
+	change_merkle_root {
+		let p in 0..10;
+		let new_root = [p as u8;32];
+		let last_root = [0u8;32];
+		MerkleRoot::<T>::put(last_root.clone());
+	}: change_merkle_root(
+		RawOrigin::Root,
+		new_root
+	) verify {
+		assert_last_event::<T>(Event::MerkleRootUpdated{
+			old_root: Some(last_root),
+			new_root,
+		}.into());
+	}
+
+	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
+}

--- a/pallets/airdrop/src/exchange_accounts.rs
+++ b/pallets/airdrop/src/exchange_accounts.rs
@@ -1,0 +1,35 @@
+pub(crate) const EXCHANGE_ACCOUNTS: &[([u8; 20], u128)] = &[
+	(
+		hex_literal::hex!("562dc1e2c7897432c298115bc7fbcc3b9d5df294"),
+		70717613544517522852341727,
+	),
+	(
+		hex_literal::hex!("61acc986a761b5f354dc8777360aeaf47b2ab616"),
+		8968750000000000000,
+	),
+	(
+		hex_literal::hex!("6d14b2b77a9e73c5d5804d43c7e3c3416648ae3d"),
+		8348890436199324029817984,
+	),
+	(
+		hex_literal::hex!("938b9a413de9ffbbeae72e7034931a3bdf0f1e96"),
+		2959971579000000000000000 + 13972742011003245391080,
+	),
+	(
+		hex_literal::hex!("d182113fea7ae3164871bfda90ec8652123aa354"),
+		352948797792142357220773,
+	),
+];
+
+use sp_runtime::traits::Convert;
+use sp_std::vec::Vec;
+use crate::{Config, types};
+pub(crate) fn get_exchange_account<T: Config>() -> Vec<(types::IconAddress, types::BalanceOf<T>)> {
+    EXCHANGE_ACCOUNTS
+        .into_iter()
+        .map(|(address, balance)|{
+            let address = *address;
+            let balance: crate::types::BalanceOf<T> = T::BalanceTypeConversion::convert(*balance);
+            (address, balance)
+        }).collect()
+}

--- a/pallets/airdrop/src/lib.rs
+++ b/pallets/airdrop/src/lib.rs
@@ -17,6 +17,8 @@ pub mod weights;
 
 pub mod merkle;
 
+mod exchange_accounts;
+
 #[cfg(not(feature = "no-vesting"))]
 pub mod vested_transfer;
 
@@ -32,7 +34,7 @@ pub use pallet::*;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::{error, info};
-	use super::{types, utils, weights};
+	use super::{types, utils, weights, exchange_accounts};
 	use hex_literal::hex;
 	use sp_runtime::traits::Convert;
 
@@ -682,7 +684,6 @@ pub mod pallet {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub exchange_accounts: Vec<(types::IconAddress, types::BalanceOf<T>)>,
 		pub creditor_account: types::AccountIdOf<T>,
 		pub merkle_root: [u8; 32],
 	}
@@ -696,10 +697,7 @@ pub mod pallet {
 				types::AccountIdOf::<T>::decode(&mut &creditor_account_hex[..]).unwrap();
 			let merkle_root = [0u8; 32];
 
-			let exchange_accounts = vec![];
-
 			Self {
-				exchange_accounts,
 				creditor_account,
 				merkle_root,
 			}
@@ -709,7 +707,8 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-			for (address, balance) in &self.exchange_accounts {
+			let exchange_accounts = exchange_accounts::get_exchange_account::<T>();
+			for (address, balance) in exchange_accounts {
 				<ExchangeAccountsMap<T>>::insert(address, balance);
 			}
 

--- a/pallets/airdrop/src/lib.rs
+++ b/pallets/airdrop/src/lib.rs
@@ -1,0 +1,720 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+pub mod tests;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
+/// All the types, traits defination and alises are inside this
+pub mod types;
+
+/// All independent utilities function are inside here
+pub mod utils;
+
+// Weight Information related to this palet
+pub mod weights;
+
+pub mod merkle;
+
+#[cfg(not(feature = "no-vesting"))]
+pub mod vested_transfer;
+
+#[cfg(feature = "no-vesting")]
+pub mod non_vested_transfer;
+
+#[cfg(not(test))]
+pub(crate) use log::{error, info};
+#[cfg(test)]
+pub(crate) use {eprintln as error, println as info};
+
+pub use pallet::*;
+#[frame_support::pallet]
+pub mod pallet {
+	use super::{error, info};
+	use super::{types, utils, weights};
+	use hex_literal::hex;
+	use sp_runtime::traits::Convert;
+
+	use frame_support::pallet_prelude::*;
+	use frame_system::{ensure_root, ensure_signed, pallet_prelude::*};
+	use sp_std::prelude::*;
+
+	use crate::merkle;
+	use crate::types::MerkelProofValidator;
+	use frame_support::storage::bounded_vec::BoundedVec;
+	use frame_support::traits::{Currency, LockableCurrency, ReservableCurrency};
+	use sp_runtime::traits::Verify;
+	use weights::WeightInfo;
+
+	// Re-exports
+	pub use types::AirdropBehaviour;
+
+	/// Configure the pallet by specifying the parameters and types on which it depends.
+	#[pallet::config]
+	pub trait Config: frame_system::Config + pallet_vesting::Config {
+		/// Because this pallet emits events, it depends on the runtime's definition of an event.
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+		type Currency: Currency<types::AccountIdOf<Self>>
+			+ ReservableCurrency<types::AccountIdOf<Self>>
+			+ LockableCurrency<types::AccountIdOf<Self>>
+			+ IsType<<Self as pallet_vesting::Config>::Currency>;
+
+		/// Weight information for extrinsics in this pallet.
+		type AirdropWeightInfo: WeightInfo;
+
+		/// Type that allows back and forth conversion
+		/// Airdrop Balance <==> Vesting Balance
+		type BalanceTypeConversion: Convert<types::ServerBalance, types::BalanceOf<Self>>
+			+ Convert<types::BalanceOf<Self>, types::ServerBalance>
+			+ Convert<types::VestingBalanceOf<Self>, types::BalanceOf<Self>>
+			+ Convert<types::BalanceOf<Self>, types::VestingBalanceOf<Self>>;
+
+		type MerkelProofValidator: types::MerkelProofValidator<Self>;
+
+		type MaxProofSize: Get<u32>;
+
+		const AIRDROP_VARIABLES: AirdropBehaviour;
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// ClaimRequest have been ok for given icon address
+		ClaimSuccess(types::IconAddress),
+
+		/// PartialClaimRequest have been ok for given icon address
+		ClaimPartialSuccess(types::IconAddress),
+
+		/// Value of ServerAccount sotrage have been changed
+		// Return old value and new one
+		ServerAccountChanged {
+			old_account: Option<types::AccountIdOf<T>>,
+			new_account: types::AccountIdOf<T>,
+		},
+
+		/// AirdropState have been updated
+		AirdropStateUpdated {
+			old_state: types::AirdropState,
+			new_state: types::AirdropState,
+		},
+
+		/// New merkle root have been set
+		MerkleRootUpdated {
+			old_root: Option<[u8; 32]>,
+			new_root: [u8; 32],
+		},
+
+		/// Creditor balance is runnning low
+		CreditorBalanceLow,
+	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn get_airdrop_state)]
+	pub(super) type AirdropChainState<T: Config> = StorageValue<_, types::AirdropState, ValueQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn get_icon_snapshot_map)]
+	pub(super) type IconSnapshotMap<T: Config> =
+		StorageMap<_, Blake2_128, types::IconAddress, types::SnapshotInfo<T>, OptionQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn get_ice_to_icon_map)]
+	pub(super) type IceIconMap<T: Config> =
+		StorageMap<_, Twox64Concat, types::AccountIdOf<T>, types::IconAddress, OptionQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn get_airdrop_server_account)]
+	pub(super) type ServerAccount<T: Config> = StorageValue<_, types::AccountIdOf<T>, OptionQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn get_exchange_account)]
+	pub type ExchangeAccountsMap<T: Config> =
+		StorageMap<_, Twox64Concat, types::IconAddress, types::BalanceOf<T>, OptionQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn try_get_merkle_root)]
+	pub type MerkleRoot<T: Config> = StorageValue<_, [u8; 32], OptionQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn try_get_creditor_account)]
+	pub(super) type CreditorAccount<T: Config> =
+		StorageValue<_, types::AccountIdOf<T>, OptionQuery>;
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// This error will occur when signature validation failed.
+		InvalidSignature,
+
+		/// Error to return when unauthorised operation is attempted
+		DeniedOperation,
+
+		/// Not all data required are supplied with
+		IncompleteData,
+
+		/// Claim has already been made so can't be made again at this time
+		ClaimAlreadyMade,
+
+		/// Coversion between partially-compatible type failed
+		FailedConversion,
+
+		/// Creditor account do not have enough USABLE balance to
+		/// undergo this transaction
+		InsufficientCreditorBalance,
+
+		/// Some operation while applying vesting failed
+		CantApplyVesting,
+
+		/// Currently no new claim request is being accepted
+		NewClaimRequestBlocked,
+
+		/// Currently processing of exchange request is blocked
+		NewExchangeRequestBlocked,
+
+		/// Given proof set was invalid to expected tree root
+		InvalidMerkleProof,
+
+		/// Provided proof size excced the maximum limit
+		ProofTooLarge,
+
+		/// This icon address have already been mapped to another ice address
+		IconAddressInUse,
+
+		/// This ice address have already been mapped to another icon address
+		IceAddressInUse,
+
+		// Airdrop pallet expect AccountId32 as AccountId
+		// and all signature verification as well as Markle proff
+		// have been constructed with this assumption
+		/// Unexpected format of AccountId
+		IncompatibleAccountId,
+
+		/// Merkle root is not set on chain yet
+		NoMerkleRoot,
+
+		/// Creditor account is not set on chain yet
+		NoCreditorAccount,
+
+		/// Provided ice address is not in expected format
+		InvalidIceAddress,
+
+		/// Invalid signature provided
+		InvalidIceSignature,
+
+		/// Couldnot get embedded ice address from message
+		FailedExtractingIceAddress,
+
+		/// Given message payload is invalid or is in unexpected format
+		InvalidMessagePayload,
+
+		/// Internal arithmetic error
+		ArithmeticError,
+
+		/// Claim amount was not expected in this exchanged airdrop
+		InvalidClaimAmount,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Dispatchable to be called by server with privileged account
+		/// dispatch claim
+		#[pallet::weight((
+			T::AirdropWeightInfo::dispatch_user_claim(),
+			DispatchClass::Normal,
+			Pays::Yes
+		))]
+		pub fn dispatch_user_claim(
+			origin: OriginFor<T>,
+			icon_address: types::IconAddress,
+			ice_address: types::IceAddress,
+			message: types::RawPayload,
+			icon_signature: types::IconSignature,
+			ice_signature: types::IceSignature,
+			total_amount: types::BalanceOf<T>,
+			defi_user: bool,
+			proofs: types::MerkleProofs<T>,
+		) -> DispatchResultWithPostInfo {
+			// Make sure only root or server account call call this
+			Self::ensure_root_or_server(origin).map_err(|_| Error::<T>::DeniedOperation)?;
+
+			// Make sure node is accepting new claimrequest
+			Self::ensure_user_claim_switch()?;
+
+			// Verify the integrity of message
+			Self::validate_message_payload(&message, &ice_address).map_err(|e| {
+				info!(
+					"claim request by: {icon_address:?}. Rejected at: validate_message_paload(). Error: {e:?}"
+				);
+				e
+			})?;
+
+			// We expect a valid proof of this exchange call
+			Self::validate_merkle_proof(&icon_address, total_amount, defi_user, proofs).map_err(
+				|e| {
+					info!(
+						"claim request by: {icon_address:?}. Rejected at: validate_merkle_proff()"
+					);
+					e
+				},
+			)?;
+
+			// Validate icon signature
+			Self::validate_icon_address(&icon_address, &icon_signature, &message).map_err(|e| {
+				info!("claim request by: {icon_address:?}. Rejected at:  validate_icon_address()");
+				e
+			})?;
+
+			// Validate ice signature
+			Self::validate_ice_signature(&ice_signature, &icon_signature, &ice_address).map_err(
+				|e| {
+					info!(
+						"claim request by: {icon_address:?}. Rejected at: validate_ice_signature()"
+					);
+					e
+				},
+			)?;
+
+			// Now this address pair is verified,
+			// we can insert it to the map if this pair is new
+			let mut snapshot =
+				Self::insert_or_get_snapshot(&icon_address, &ice_address, defi_user, total_amount)
+					.map_err(|e| {
+						info!("claim request by: {icon_address:?}. Rejected at: insert_or_get_snapshot. error: {e:?}");
+						e
+					})?;
+
+			// Make sure this user is eligible for claim.
+			Self::ensure_claimable(&snapshot).map_err(|e| {
+				info!("claim requet by: {icon_address:?}. Rejected at: ensure_claimable(). Snapshot: {snapshot:?}.");
+				e
+			})?;
+
+			// We also make sure creditor have enough fund to complete this airdrop
+			Self::validate_creditor_fund(total_amount).map_err(|e| {
+				error!("claim requet by: {icon_address:?}. Rejected at: validate_creditor_fund(). Amount: {total_amount:?}");
+				e
+			})?;
+
+			// Do the actual transfer if eligible
+			Self::do_transfer(&mut snapshot, &icon_address).map_err(|e| {
+				info!("claim request by: {icon_address:?}. Failed at: do_transfer(). Reason: {e:?}. Snapshot: {snapshot:?}");
+				e
+			})?;
+
+			Self::deposit_event(Event::ClaimSuccess(icon_address));
+			Ok(Pays::No.into())
+		}
+
+		#[pallet::weight((
+			T::AirdropWeightInfo::dispatch_exchange_claim(),
+			DispatchClass::Normal,
+			Pays::Yes
+		))]
+		pub fn dispatch_exchange_claim(
+			origin: OriginFor<T>,
+			icon_address: types::IconAddress,
+			ice_address: types::IceAddress,
+			total_amount: types::BalanceOf<T>,
+			defi_user: bool,
+			proofs: types::MerkleProofs<T>,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin).map_err(|_| Error::<T>::DeniedOperation)?;
+			Self::ensure_exchange_claim_switch()?;
+
+			let amount = Self::validate_whitelisted(&icon_address)?;
+			ensure!(total_amount == amount, Error::<T>::InvalidClaimAmount);
+
+			Self::validate_merkle_proof(&icon_address, total_amount, defi_user, proofs).map_err(
+				|e| {
+					info!(
+						"Exchange for: {icon_address:?}. Failed at: validate_merkle_proof(). Reason: {e:?}"
+					);
+					e
+				},
+			)?;
+			Self::validate_creditor_fund(total_amount).map_err(|e| {
+				error!("Exchange for: {icon_address:?}. Failed at: validate_creditor_fund. Amount: {total_amount:?}");
+				e
+			})?;
+
+			let mut snapshot =
+				Self::insert_or_get_snapshot(&icon_address, &ice_address, defi_user, total_amount)
+					.map_err(|e| {
+						error!("Exhange for: {icon_address:?}. Failed at: insert_or_get_snapshot.");
+						e
+					})?;
+
+			Self::ensure_claimable(&snapshot).map_err(|e| {
+				info!("Exchange for: {icon_address:?}. Failed at: ensure_claimable. Snapshot: {snapshot:?}");
+				e
+			})?;
+			Self::do_transfer(&mut snapshot, &icon_address).map_err(|e| {
+				info!("Exchange for: {icon_address:?}. Failed at: do_transfer. Snapshot: {snapshot:?}. Reason: {e:?}");
+				e
+			})?;
+
+			Self::deposit_event(Event::ClaimSuccess(icon_address));
+			Ok(Pays::No.into())
+		}
+
+		#[pallet::weight(<T as Config>::AirdropWeightInfo::set_airdrop_server_account())]
+		pub fn set_airdrop_server_account(
+			origin: OriginFor<T>,
+			new_account: types::AccountIdOf<T>,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin).map_err(|_| Error::<T>::DeniedOperation)?;
+
+			let old_account = Self::get_airdrop_server_account();
+			<ServerAccount<T>>::set(Some(new_account.clone()));
+
+			info!(
+				"Server account changed from {old_account:?} to {new_account:?} at height: {bl_num:?}",
+				bl_num = utils::get_current_block_number::<T>(),
+			);
+
+			Self::deposit_event(Event::ServerAccountChanged {
+				old_account,
+				new_account,
+			});
+
+			Ok(Pays::No.into())
+		}
+
+		#[pallet::weight(<T as Config>::AirdropWeightInfo::change_merkle_root())]
+		pub fn change_merkle_root(origin: OriginFor<T>, new_root: [u8; 32]) -> DispatchResult {
+			ensure_root(origin).map_err(|_| Error::<T>::DeniedOperation)?;
+			let old_root = Self::try_get_merkle_root();
+
+			MerkleRoot::<T>::put(&new_root);
+
+			info!(
+				"Merkle root changed from {old_root:?} to {new_root:?} at height {bl_num:?}",
+				bl_num = utils::get_current_block_number::<T>()
+			);
+
+			Self::deposit_event(Event::<T>::MerkleRootUpdated { old_root, new_root });
+			Ok(())
+		}
+
+		#[pallet::weight(<T as Config>::AirdropWeightInfo::update_airdrop_state())]
+		pub fn update_airdrop_state(
+			origin: OriginFor<T>,
+			new_state: types::AirdropState,
+		) -> DispatchResultWithPostInfo {
+			// Only root can call this
+			ensure_root(origin).map_err(|_| Error::<T>::DeniedOperation)?;
+
+			let old_state = Self::get_airdrop_state();
+			<AirdropChainState<T>>::set(new_state.clone());
+
+			info!(
+				"Airdrop state changed from {old_state:?} to {new_state:?} at height: {bl_num:?}",
+				bl_num = utils::get_current_block_number::<T>(),
+			);
+
+			Self::deposit_event(Event::AirdropStateUpdated {
+				old_state,
+				new_state,
+			});
+
+			Ok(Pays::No.into())
+		}
+	}
+
+	// implement all the helper function that are called from pallet dispatchable
+	impl<T: Config> Pallet<T> {
+		/// Check weather node is set to block incoming claim request
+		/// Return error in that case else return Ok
+		pub fn ensure_user_claim_switch() -> DispatchResult {
+			let is_disabled = Self::get_airdrop_state().block_claim_request;
+
+			if is_disabled {
+				Err(Error::<T>::NewClaimRequestBlocked.into())
+			} else {
+				Ok(())
+			}
+		}
+
+		pub fn get_creditor_account() -> Result<types::AccountIdOf<T>, Error<T>> {
+			Self::try_get_creditor_account().ok_or(Error::<T>::NoCreditorAccount)
+		}
+
+		pub fn get_merkle_root() -> Result<[u8; 32], Error<T>> {
+			Self::try_get_merkle_root().ok_or(Error::<T>::NoMerkleRoot)
+		}
+
+		/// Check weather node is set to block incoming exchange request
+		/// Return error in that case else return Ok
+		pub fn ensure_exchange_claim_switch() -> DispatchResult {
+			let is_disabled = Self::get_airdrop_state().block_exchange_request;
+
+			if is_disabled {
+				Err(Error::<T>::NewExchangeRequestBlocked.into())
+			} else {
+				Ok(())
+			}
+		}
+
+		/// Helper function to create similar interface like `ensure_root`
+		/// but which instead check for server key
+		pub fn ensure_root_or_server(origin: OriginFor<T>) -> DispatchResult {
+			let is_root = ensure_root(origin.clone()).is_ok();
+			let is_offchain = {
+				let signed = ensure_signed(origin);
+				signed.is_ok() && signed.ok() == Self::get_airdrop_server_account()
+			};
+
+			ensure!(is_root || is_offchain, DispatchError::BadOrigin);
+			Ok(())
+		}
+
+		// Insert this address pair if it is new
+		pub fn insert_or_get_snapshot(
+			icon_address: &types::IconAddress,
+			ice_address: &types::IceAddress,
+			defi_user: bool,
+			amount: types::BalanceOf<T>,
+		) -> Result<types::SnapshotInfo<T>, DispatchError> {
+			let ice_account =
+				Self::to_account_id(ice_address.to_vec().try_into().map_err(|_| {
+					error!(
+						"received ice_address: {ice_address:?} cannot be converted into [u8; 32]"
+					);
+					Error::<T>::IncompatibleAccountId
+				})?)
+				.map_err(|_| {
+					error!("ice address bytes: {ice_address:?} cannot be converted into AccountId");
+					Error::<T>::IncompatibleAccountId
+				})?;
+
+			let old_snapshot = Self::get_icon_snapshot_map(&icon_address);
+			let old_icon_address = Self::get_ice_to_icon_map(&ice_account);
+
+			if let Some(old_icon_address) = old_icon_address {
+				ensure!(&old_icon_address == icon_address, {
+					info!("For ice: {ice_address:?}. new icon address is: {old_icon_address:?}. Rejected, old was: {old_icon_address:?}");
+					Error::<T>::IconAddressInUse
+				});
+			}
+
+			if let Some(old_snapshot) = &old_snapshot {
+				let old_ice_address = &old_snapshot.ice_address;
+				ensure!(old_ice_address.eq(&ice_account), {
+					info!("For icon: {icon_address:?}. new ice address is: {ice_account:?}. Rejected, old was: {old_ice_address:?}");
+					Error::<T>::IceAddressInUse
+				});
+			}
+
+			let icon_address = old_icon_address.as_ref().unwrap_or_else(|| {
+				<IceIconMap<T>>::insert(&ice_account, icon_address);
+				icon_address
+			});
+
+			let snapshot = old_snapshot.unwrap_or_else(|| {
+				let new_snapshot =
+					types::SnapshotInfo::<T>::new(ice_account.clone(), defi_user, amount);
+
+				<IconSnapshotMap<T>>::insert(icon_address, &new_snapshot);
+
+				new_snapshot
+			});
+
+			Ok(snapshot)
+		}
+
+		pub fn ensure_claimable(snapshot: &types::SnapshotInfo<T>) -> DispatchResult {
+			#[cfg(not(feature = "no-vesting"))]
+			let already_claimed = snapshot.done_instant && snapshot.done_vesting;
+
+			#[cfg(feature = "no-vesting")]
+			let already_claimed = snapshot.done_instant;
+
+			if already_claimed {
+				Err(Error::<T>::ClaimAlreadyMade.into())
+			} else {
+				Ok(())
+			}
+		}
+
+		pub fn validate_creditor_fund(required_amount: types::BalanceOf<T>) -> DispatchResult {
+			let creditor_balance =
+				<T as Config>::Currency::free_balance(&Self::get_creditor_account()?);
+			let exestensial_deposit = <T as Config>::Currency::minimum_balance();
+
+			if creditor_balance > required_amount + exestensial_deposit {
+				Ok(())
+			} else {
+				Self::deposit_event(Event::<T>::CreditorBalanceLow);
+				Err(Error::<T>::InsufficientCreditorBalance.into())
+			}
+		}
+
+		pub fn validate_whitelisted(
+			icon_address: &types::IconAddress,
+		) -> Result<types::BalanceOf<T>, Error<T>> {
+			Self::get_exchange_account(icon_address).ok_or(Error::<T>::DeniedOperation)
+		}
+
+		pub fn validate_icon_address(
+			icon_address: &types::IconAddress,
+			signature: &types::IconSignature,
+			payload: &[u8],
+		) -> Result<(), Error<T>> {
+			let recovered_key = utils::recover_address(signature, payload)?;
+			ensure!(
+				recovered_key == icon_address.as_slice(),
+				Error::<T>::InvalidSignature
+			);
+			Ok(())
+		}
+
+		pub fn validate_ice_signature(
+			signature_raw: &[u8; 64],
+			msg: &[u8],
+			ice_bytes: &types::IceAddress,
+		) -> Result<bool, Error<T>> {
+			let wrapped_msg = utils::wrap_bytes(msg);
+
+			let is_valid = Self::check_signature(signature_raw, &wrapped_msg, ice_bytes);
+			if is_valid {
+				Ok(true)
+			} else {
+				Err(Error::<T>::InvalidIceSignature)
+			}
+		}
+
+		pub fn validate_message_payload(
+			payload: &[u8],
+			ice_address: &[u8; 32],
+		) -> Result<(), Error<T>> {
+			let extracted_address = utils::extract_ice_address(payload, ice_address)
+				.map_err(|_e| Error::<T>::FailedExtractingIceAddress)?;
+			ensure!(
+				extracted_address == ice_address,
+				Error::<T>::InvalidMessagePayload
+			);
+			Ok(())
+		}
+
+		pub fn check_signature(
+			signature_raw: &[u8; 64],
+			msg: &[u8],
+			account_bytes: &[u8; 32],
+		) -> bool {
+			let signature = sp_core::sr25519::Signature::from_raw(*signature_raw);
+			let public = sp_core::sr25519::Public::from_raw(*account_bytes);
+			signature.verify(msg, &public)
+		}
+
+		pub fn get_bounded_proofs(
+			input: Vec<types::MerkleHash>,
+		) -> Result<BoundedVec<types::MerkleHash, T::MaxProofSize>, Error<T>> {
+			let bounded_vec = BoundedVec::<types::MerkleHash, T::MaxProofSize>::try_from(input)
+				.map_err(|()| Error::<T>::ProofTooLarge)?;
+			Ok(bounded_vec)
+		}
+
+		pub fn validate_merkle_proof(
+			icon_address: &types::IconAddress,
+			amount: types::BalanceOf<T>,
+			defi_user: bool,
+			proof_hashes: types::MerkleProofs<T>,
+		) -> DispatchResult {
+			let amount = types::from_balance::<T>(amount);
+			let leaf_hash = merkle::hash_leaf(icon_address, amount, defi_user);
+			let merkle_root = Self::get_merkle_root()?;
+
+			let is_valid_proof =
+				<T as Config>::MerkelProofValidator::validate(leaf_hash, merkle_root, proof_hashes);
+			if !is_valid_proof {
+				return Err(Error::<T>::InvalidMerkleProof.into());
+			}
+
+			Ok(())
+		}
+
+		pub fn to_account_id(ice_bytes: [u8; 32]) -> Result<types::AccountIdOf<T>, Error<T>> {
+			<T as frame_system::Config>::AccountId::decode(&mut &ice_bytes[..])
+				.map_err(|_e| Error::<T>::InvalidIceAddress)
+		}
+
+		pub fn do_transfer(
+			snapshot: &mut types::SnapshotInfo<T>,
+			icon_address: &types::IconAddress,
+		) -> Result<(), DispatchError> {
+			use types::DoTransfer;
+
+			#[cfg(not(feature = "no-vesting"))]
+			type TransferType = super::vested_transfer::DoVestdTransfer;
+
+			#[cfg(feature = "no-vesting")]
+			type TransferType = super::non_vested_transfer::AllInstantTransfer;
+
+			let transfer_result = TransferType::do_transfer(snapshot);
+
+			// No matter the result we will write the updated_snapshot
+			<IconSnapshotMap<T>>::insert(icon_address, snapshot);
+
+			// Now snapshot have been written, return result
+			transfer_result
+		}
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	impl<T: Config> Pallet<T> {
+		pub fn init_balance(account: &types::AccountIdOf<T>, free: types::ServerBalance) {
+			let amount = <T::BalanceTypeConversion as Convert<_, _>>::convert(free);
+			<T as Config>::Currency::make_free_balance_be(account, amount);
+		}
+
+		pub fn set_creditor_account(new_account: sp_core::sr25519::Public) {
+			let mut account_bytes = new_account.0.clone();
+			let account = T::AccountId::decode(&mut &account_bytes[..]).unwrap();
+
+			<CreditorAccount<T>>::set(Some(account.clone()));
+		}
+	}
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		pub exchange_accounts: Vec<(types::IconAddress, types::BalanceOf<T>)>,
+		pub creditor_account: types::AccountIdOf<T>,
+		pub merkle_root: [u8; 32],
+	}
+
+	#[cfg(feature = "std")]
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			let creditor_account_hex =
+				hex!["d893ef775b5689473b2e9fa32c1f15c72a7c4c86f05f03ee32b8aca6ce61b92c"];
+			let creditor_account =
+				types::AccountIdOf::<T>::decode(&mut &creditor_account_hex[..]).unwrap();
+			let merkle_root = [0u8; 32];
+
+			let exchange_accounts = vec![];
+
+			Self {
+				exchange_accounts,
+				creditor_account,
+				merkle_root,
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+		fn build(&self) {
+			for (address, balance) in &self.exchange_accounts {
+				<ExchangeAccountsMap<T>>::insert(address, balance);
+			}
+
+			CreditorAccount::<T>::put(&self.creditor_account);
+			MerkleRoot::<T>::put(&self.merkle_root);
+		}
+	}
+}

--- a/pallets/airdrop/src/merkle.rs
+++ b/pallets/airdrop/src/merkle.rs
@@ -1,0 +1,66 @@
+use crate::types;
+use crate::Config;
+use codec::alloc::string::ToString;
+use core::cmp::Ordering;
+use core::marker::PhantomData;
+use sp_io::hashing;
+use sp_std::prelude::*;
+use types::MerkelProofValidator;
+
+pub struct AirdropMerkleValidator<T>(PhantomData<T>);
+
+impl<T: Config> MerkelProofValidator<T> for AirdropMerkleValidator<T> {
+	fn validate(
+		leaf_hash: types::MerkleHash,
+		root_hash: types::MerkleHash,
+		proofs: types::MerkleProofs<T>,
+	) -> bool {
+		let computed_root = hex::encode(proof_root(leaf_hash, proofs.to_vec()));
+		let root_hex = hex::encode(root_hash);
+
+		computed_root == root_hex
+	}
+}
+
+pub fn hash_leaf(
+	icon_address: &types::IconAddress,
+	amount: types::ServerBalance,
+	defi_user: bool,
+) -> [u8; 32] {
+	let defi_str = if defi_user { "1" } else { "0" };
+	let mut byte_vec = icon_address.to_vec();
+	byte_vec.extend_from_slice(amount.to_string().as_bytes());
+	byte_vec.extend_from_slice(&defi_str.as_bytes());
+	hashing::blake2_256(&byte_vec)
+}
+
+pub fn proof_root(leaf_hash: types::MerkleHash, proofs: Vec<types::MerkleHash>) -> [u8; 32] {
+	let mut one = leaf_hash;
+	for proof in proofs {
+		one = create_hash(one, proof);
+	}
+
+	one
+}
+
+pub fn create_hash(one: types::MerkleHash, other: types::MerkleHash) -> [u8; 32] {
+	let sorted = sort_array(one, other, 0 as usize);
+	hashing::blake2_256(&sorted)
+}
+
+pub fn sort_array(one: types::MerkleHash, other: types::MerkleHash, pos: usize) -> Vec<u8> {
+	let max_pos = 31 as usize;
+	let mut pos = pos;
+	let ord = one[pos].cmp(&other[pos]);
+	match ord {
+		Ordering::Greater => [other, one].concat(),
+		Ordering::Less => [one, other].concat(),
+		Ordering::Equal => {
+			if pos == max_pos {
+				return [one, other].concat();
+			}
+			pos += 1;
+			sort_array(one, other, pos)
+		}
+	}
+}

--- a/pallets/airdrop/src/non_vested_transfer.rs
+++ b/pallets/airdrop/src/non_vested_transfer.rs
@@ -1,0 +1,40 @@
+use crate as airdrop;
+use airdrop::{error, info};
+use airdrop::{types, utils, Pallet as AirdropModule};
+use frame_support::pallet_prelude::*;
+use frame_support::traits::{Currency, ExistenceRequirement};
+
+pub struct AllInstantTransfer;
+
+impl types::DoTransfer for AllInstantTransfer {
+	fn do_transfer<T: airdrop::Config>(snapshot: &mut types::SnapshotInfo<T>) -> DispatchResult {
+		let creditor = AirdropModule::<T>::get_creditor_account()?;
+		let claimer = &snapshot.ice_address;
+		let total_balance = snapshot.amount;
+
+		if !snapshot.done_instant {
+			<T as airdrop::Config>::Currency::transfer(
+				&creditor,
+				&claimer,
+				total_balance,
+				ExistenceRequirement::KeepAlive,
+			)
+			.map_err(|e| {
+				info!("At: AllInstant::do_transfer. Claimer: {claimer:?}. Reason: {e:?}");
+				e
+			})?;
+
+			// Everything went ok. Update flag
+			snapshot.done_instant = true;
+			snapshot.initial_transfer = total_balance;
+			snapshot.instant_block_number = Some(utils::get_current_block_number::<T>());
+		} else {
+			info!(
+				"At: AllInstantTransfer::do_transfer. Skipped for claimer: {claimer:?}.{reason}",
+				reason = "snapshot.done_instant was true already"
+			);
+		}
+
+		Ok(())
+	}
+}

--- a/pallets/airdrop/src/tests/exchange_claim.rs
+++ b/pallets/airdrop/src/tests/exchange_claim.rs
@@ -1,0 +1,243 @@
+use codec::Encode;
+use frame_support::{traits::ConstU32, BoundedVec};
+
+use crate::tests::to_test_case;
+
+use super::prelude::*;
+const VALID_ICON_WALLET: types::IconAddress =
+	decode_hex!("ee1448f0867b90e6589289a4b9c06ac4516a75a9");
+
+#[test]
+fn claim_success() {
+	let sample = samples::MERKLE_PROOF_SAMPLE;
+	let case = to_test_case(sample);
+	let bounded_proofs = BoundedVec::<types::MerkleHash, ConstU32<10>>::try_from(case.1).unwrap();
+	let defi_user = true;
+	let amount: types::BalanceOf<Test> = 10017332_u64.into();
+	let mut test_ext = minimal_test_ext();
+	test_ext.execute_with(|| {
+		let icon_wallet = VALID_ICON_WALLET;
+		let ice_address =
+			hex_literal::hex!("da8db20713c087e12abae13f522693299b9de1b70ff0464caa5d392396a8f76c");
+		let ice_address = AirdropModule::to_account_id(ice_address.clone()).unwrap();
+
+		pallet_airdrop::ExchangeAccountsMap::<Test>::insert(icon_wallet, amount);
+		set_creditor_balance(10_000_0000);
+
+		assert_ok!(AirdropModule::dispatch_exchange_claim(
+			Origin::root(),
+			icon_wallet,
+			ice_address.encode().try_into().unwrap(),
+			amount.into(),
+			defi_user,
+			bounded_proofs,
+		));
+
+		let snapshot = AirdropModule::get_icon_snapshot_map(&icon_wallet).unwrap();
+
+		// Ensure mapping in both storage are correct
+		let mapped_icon_wallet = AirdropModule::get_ice_to_icon_map(&ice_address);
+		assert_eq!(mapped_icon_wallet, Some(icon_wallet));
+
+		// Ensure transfer flag are updated
+		assert!(snapshot.done_instant);
+		assert_eq!(Some(0), snapshot.instant_block_number);
+
+		#[cfg(not(feature = "no-vesting"))]
+		{
+			assert!(snapshot.done_vesting);
+			assert_eq!(Some(0), snapshot.vesting_block_number);
+		}
+	});
+}
+
+#[test]
+fn insufficient_balance() {
+	let sample = samples::MERKLE_PROOF_SAMPLE;
+	let case = to_test_case(sample);
+	let bounded_proofs = BoundedVec::<types::MerkleHash, ConstU32<10>>::try_from(case.1).unwrap();
+	let defi_user = true;
+	let amount: types::BalanceOf<Test> = 10017332_u64.into();
+	let mut test_ext = minimal_test_ext();
+	test_ext.execute_with(|| {
+		let icon_wallet = VALID_ICON_WALLET;
+		let ice_address =
+			hex_literal::hex!("da8db20713c087e12abae13f522693299b9de1b70ff0464caa5d392396a8f76c");
+
+		let creditor_account = force_get_creditor_account::<Test>();
+		pallet_airdrop::ExchangeAccountsMap::<Test>::insert(&icon_wallet, amount);
+		<Test as pallet_airdrop::Config>::Currency::set_balance(
+			mock::Origin::root(),
+			creditor_account,
+			10_u32.into(),
+			10_u32.into(),
+		)
+		.unwrap();
+
+		assert_err!(
+			AirdropModule::dispatch_exchange_claim(
+				Origin::root(),
+				icon_wallet,
+				ice_address.clone(),
+				amount,
+				defi_user,
+				bounded_proofs,
+			),
+			PalletError::InsufficientCreditorBalance
+		);
+	});
+}
+
+#[test]
+fn double_exchange() {
+	let exchange_once = || {
+		set_creditor_balance(10_00_00_0000);
+
+		let case = to_test_case(samples::MERKLE_PROOF_SAMPLE);
+		let bounded_proofs =
+			BoundedVec::<types::MerkleHash, ConstU32<10>>::try_from(case.1).unwrap();
+		let amount: types::BalanceOf<Test> = 10017332_u64.into();
+		let icon_wallet = VALID_ICON_WALLET;
+		let ice_address =
+			hex_literal::hex!("da8db20713c087e12abae13f522693299b9de1b70ff0464caa5d392396a8f76c");
+		pallet_airdrop::ExchangeAccountsMap::<Test>::insert(&icon_wallet, amount);
+
+		AirdropModule::dispatch_exchange_claim(
+			Origin::root(),
+			icon_wallet,
+			ice_address.clone(),
+			amount,
+			true,
+			bounded_proofs,
+		)
+	};
+
+	minimal_test_ext().execute_with(|| {
+		let first_exchange = exchange_once();
+		let second_exchange = exchange_once();
+
+		// First exchange should pass
+		assert_ok!(first_exchange);
+
+		// Second exchange should fail
+		assert_err!(second_exchange, PalletError::ClaimAlreadyMade);
+	});
+}
+
+#[test]
+fn already_claimed() {
+	let sample = samples::MERKLE_PROOF_SAMPLE;
+	let case = to_test_case(sample);
+	let bounded_proofs = BoundedVec::<types::MerkleHash, ConstU32<10>>::try_from(case.1).unwrap();
+	let defi_user = true;
+	let amount: types::BalanceOf<Test> = 1;
+
+	minimal_test_ext().execute_with(|| {
+		set_creditor_balance(10_000_0000_u32.into());
+
+		let icon_wallet = VALID_ICON_WALLET;
+		let ice_address =
+			hex_literal::hex!("da8db20713c087e12abae13f522693299b9de1b70ff0464caa5d392396a8f76c");
+		let ice_account = AirdropModule::to_account_id(ice_address).unwrap();
+
+		let mut snapshot = types::SnapshotInfo::default().ice_address(ice_account.clone());
+		snapshot.done_instant = true;
+		snapshot.done_vesting = true;
+
+		pallet_airdrop::IconSnapshotMap::<Test>::insert(&icon_wallet, snapshot);
+		pallet_airdrop::ExchangeAccountsMap::<Test>::insert(&icon_wallet, amount);
+
+		assert_err!(
+			AirdropModule::dispatch_exchange_claim(
+				Origin::root(),
+				icon_wallet,
+				ice_address.clone(),
+				amount,
+				defi_user,
+				bounded_proofs,
+			),
+			PalletError::ClaimAlreadyMade
+		);
+	});
+}
+
+#[test]
+fn only_whitelisted_claim() {
+	let sample = samples::MERKLE_PROOF_SAMPLE;
+	let case = to_test_case(sample);
+	let bounded_proofs = BoundedVec::<types::MerkleHash, ConstU32<10>>::try_from(case.1).unwrap();
+	let defi_user = true;
+	let amount: types::BalanceOf<Test> = 10017332_u64.into();
+	let mut test_ext = minimal_test_ext();
+	test_ext.execute_with(|| {
+		let icon_wallet = VALID_ICON_WALLET;
+		let ice_address =
+			hex_literal::hex!("da8db20713c087e12abae13f522693299b9de1b70ff0464caa5d392396a8f76c");
+
+		let snapshot = types::SnapshotInfo::default();
+
+		pallet_airdrop::IconSnapshotMap::<Test>::insert(&icon_wallet, snapshot);
+		let creditor_account = force_get_creditor_account::<Test>();
+		<Test as pallet_airdrop::Config>::Currency::set_balance(
+			mock::Origin::root(),
+			creditor_account,
+			10_000_0000_u32.into(),
+			10_000_00_u32.into(),
+		)
+		.unwrap();
+
+		assert_err!(
+			AirdropModule::dispatch_exchange_claim(
+				Origin::root(),
+				icon_wallet,
+				ice_address.clone(),
+				amount,
+				defi_user,
+				bounded_proofs,
+			),
+			PalletError::DeniedOperation
+		);
+	});
+}
+
+#[test]
+fn invalid_claim_amount() {
+	let sample = samples::MERKLE_PROOF_SAMPLE;
+	let case = to_test_case(sample);
+	let bounded_proofs = BoundedVec::<types::MerkleHash, ConstU32<10>>::try_from(case.1).unwrap();
+	let defi_user = true;
+	let amount: types::BalanceOf<Test> = 10017332_u64.into();
+	let mut test_ext = minimal_test_ext();
+	test_ext.execute_with(|| {
+		let icon_wallet = VALID_ICON_WALLET;
+		let ice_address =
+			hex_literal::hex!("da8db20713c087e12abae13f522693299b9de1b70ff0464caa5d392396a8f76c");
+
+		let mut snapshot = types::SnapshotInfo::default();
+		snapshot.done_instant = true;
+		snapshot.done_vesting = true;
+
+		pallet_airdrop::IconSnapshotMap::<Test>::insert(&icon_wallet, snapshot);
+		let creditor_account = force_get_creditor_account::<Test>();
+		pallet_airdrop::ExchangeAccountsMap::<Test>::insert(&icon_wallet, amount);
+		<Test as pallet_airdrop::Config>::Currency::set_balance(
+			mock::Origin::root(),
+			creditor_account,
+			10_000_0000_u32.into(),
+			10_000_00_u32.into(),
+		)
+		.unwrap();
+
+		assert_err!(
+			AirdropModule::dispatch_exchange_claim(
+				Origin::root(),
+				icon_wallet,
+				ice_address.clone(),
+				amount + 10000,
+				defi_user,
+				bounded_proofs,
+			),
+			PalletError::InvalidClaimAmount
+		);
+	});
+}

--- a/pallets/airdrop/src/tests/merkle_tests.rs
+++ b/pallets/airdrop/src/tests/merkle_tests.rs
@@ -1,0 +1,188 @@
+use crate::merkle::{hash_leaf, proof_root, sort_array};
+use crate::utils;
+use hex_literal;
+
+#[test]
+fn test_hash_leaf() {
+	let expected = "7fe522d63ebcabfa052eec3647366138c23c9870995f4af94d9b22b8c5923f49";
+	let icon_addr: [u8; 20] = hex_literal::hex!("a99344ea068864f8af6cbcf89328d6eb3d7e8c9c");
+	let result = hex::encode(hash_leaf(&icon_addr, 0, true));
+	assert_eq!(expected, &result);
+}
+
+#[test]
+fn test_verify_proof() {
+	let root = "0ad37ff10c4e2f80b4f66c376077e664e5333fd6e256385cf7ff2b03952bb2e2";
+	let cases = [
+		(
+			"7fe522d63ebcabfa052eec3647366138c23c9870995f4af94d9b22b8c5923f49",
+			[
+				"813340daefd7f1ca705faf8318cf6455632259d113c06e97b70eeeccd43519a9",
+				"409519ab7129397bdc895e4da05871c9725697a5e092addf2fe90f6e795feb8f",
+				"38055bb872670c69ac3461707f8c0b4b8e436eecfc84cfd80db30db3030c489a",
+			]
+			.to_vec(),
+		),
+		(
+			"c0401b78aed1385426cf3edba8f8b2d25f9fae0f26883fe9b72cf9b4f2d121f0",
+			[
+				"be77163fe3d25465685bb3d8004b7a8b6a260906b9d4e5fa49427c2f1b789f10",
+				"15defb2be27c700d7e3e673652a8dd7609c6d6f84f4dd007880884e0701bcb38",
+			]
+			.to_vec(),
+		),
+		(
+			"be77163fe3d25465685bb3d8004b7a8b6a260906b9d4e5fa49427c2f1b789f10",
+			[
+				"c0401b78aed1385426cf3edba8f8b2d25f9fae0f26883fe9b72cf9b4f2d121f0",
+				"15defb2be27c700d7e3e673652a8dd7609c6d6f84f4dd007880884e0701bcb38",
+			]
+			.to_vec(),
+		),
+		(
+			"23ac30dcdf69edb2f243b94608340ba3164424c24f9b5c0f56959b737327b515",
+			[
+				"4b4bb156d99b6d40e8edfa3c0d50fc4296452276b5cd4f936bceddee37c0505d",
+				"d7608226420bd49c0d8e5f79a58c5d693341f2c299911abc1eb96665b85e551d",
+				"38055bb872670c69ac3461707f8c0b4b8e436eecfc84cfd80db30db3030c489a",
+			]
+			.to_vec(),
+		),
+	];
+	for case in cases {
+		verify_proof_case(root, case.0, case.1);
+	}
+}
+
+#[test]
+fn test_verify_proof_real() {
+	let root = "4c59b428da385567a6d42ee1881ecbe43cf30bf8c4499887b7c6f689d23d4672";
+	let cases = [
+		(
+			"e56abc4f8308afe283b128761e3d00202aa3fa502526b317b37e114a5d52416c",
+			[
+				"e5c1cefc1be025a1f2851d1c21a1e4417fb89a8ac8a10d3655c915a514160c9d",
+				"beab672f1c4ec3b1851d054f8e9ecae5f45646d3c67398174cd4c6d0ae9e15d6",
+				"92379acb8de9c3999d5e34bb0c280ba3a7ea8a7fb92474099b9f05c1e5856b57",
+				"3ad35d31ebe6d14143f2401f2fa9d5816dc5cfb12c9041afbf1f653a381ba289",
+				"7af4325e3a2a279b581ba9877800c1ef77e9f8208b8750b3dd46c7848f337491",
+				"c2d3826ca7c9ed3c53e4757e5b222083f985f07109c800d5e4090dca8cb94779",
+				"5e23727864ebad198df2f497cb3e74455f280dad3c92c3b368bddd91dafd48ec",
+				"703ad3a90417ac11be663bd45122ef7bb139e2ccde51889c1c3922c93e78f8b7",
+				"335fb756d0b76f5ddba80a4238ad8b19e2fda8e620de8fc8eeabef08e53c8c1c",
+				"ab12930064ec318bb8501d88670d659da956a1cdb30cbf7033f561d6368c40e9",
+			]
+			.to_vec(),
+		),
+		(
+			"80e0c54fffa1fccedec918897b988e5a396cf86afa9d56f86f3e75cf5dd6beb8",
+			[
+				"80f607b0d69e05f187a1c481cdb7f40a2d8d9d23e694c96486a80dcc5b15e8d7",
+				"61a8a6ccc07f7cc8563892120a0a818475055db01c221b1f45369f28ab4fde4a",
+				"e71a091b1e8ad13a511d4fee208b2c0cc80e9fedd457c400fdd9de863fd1cbae",
+				"679566d212dc6e753d3aa25fbd31620a8bc6f0632c58583d9ffbccb9234d899f",
+				"5c0fe24772fa2c22212448a70cd086901ae9bfe23c125adad9363705a24aa21f",
+				"84773b8829d2ee30a7a9e3284545585a68f6a55a0327c78c6cc8a32c43bc54b1",
+				"8b51868abe71d47d25c0320f6f20fc98f0d2c871de458eb1c27d0a35025dda1d",
+				"119ad5bf90649c0facab1b8ac79aa6b7f86e9d4f515416973c3a369c5159496f",
+				"b7eadaab875f75c76e53d097e843d7c1bdb3588d039dfd8135b881c531ff81ea",
+				"fb8164dab56af7180161c00e3f52d149cdc965d431f6b4c4a4900d70d51cc07d",
+			]
+			.to_vec(),
+		),
+		(
+			"59c897680f5bf10d7ee3220b09122850366382ebbf58a64d0b5fc30980050635",
+			[
+				"5a27f7e3e8d8b5318af373d069b9d18a872fc9985ed366ea24f690b8cdbdbf95",
+				"af696a54a2127c55df65e32b0750b499460045b2ff6615b9da78ad58283357e2",
+				"bf2f0e4eaadf121e71ce8bbb7ee9960fe5212dfb84468f884a8e4e57e61e7283",
+				"8d75b5b1270191fd911374baed4bd6e1f6d9781f2707ba95f13d1fb704dd9184",
+				"1cff6a1bd58b0cabb43e0259301b894483244df086c369c7f86d8e798af5fe5f",
+				"df249d276430cc76524bfa35ece6407f9c6c8f4a1f5ac65b8702ce295f9014df",
+				"89a56eaeb1d15212ba14e0a9e1dd2e2eed26f3667de97b5ae9147678dd909ff4",
+				"cb12817002e9fb84b284efdcf8003eede561bacf8fe9fe452e37c9156a638ba6",
+				"b7eadaab875f75c76e53d097e843d7c1bdb3588d039dfd8135b881c531ff81ea",
+				"fb8164dab56af7180161c00e3f52d149cdc965d431f6b4c4a4900d70d51cc07d",
+			]
+			.to_vec(),
+		),
+		(
+			"6957d6b1ff44e34e3a5135d22d22de1b13a1be3879d20a82309a6053175cbe45",
+			[
+				"68ce45479b6abe7f059e44e0d1b2377de9eae5a5e58d7346f61aedc14228ca5d",
+				"88998e74d649a12eccffbd30c3ea41565888b341a32ee608a89231d055404797",
+				"75f735e7b39986b5a61794f4e25d25d7b3874ea49e23436a9bf242a1dd7bf2e6",
+				"db83f23d14ab7e9369147b7d4148a23156de1a9cc82695647821c6ea50006c85",
+				"f5f2b94cbc67bd0703c55380a14794d5703783fbcd793aa7a14f86d06995039c",
+				"1f46436e7b14ee57da20425a6bcc5485affc02f5839744922e713c26f6c1066b",
+				"efc70368687b58f487cc3369794a4d5265c42be00186d51e610d8d987e963b81",
+				"119ad5bf90649c0facab1b8ac79aa6b7f86e9d4f515416973c3a369c5159496f",
+				"b7eadaab875f75c76e53d097e843d7c1bdb3588d039dfd8135b881c531ff81ea",
+				"fb8164dab56af7180161c00e3f52d149cdc965d431f6b4c4a4900d70d51cc07d",
+			]
+			.to_vec(),
+		),
+	];
+	for case in cases {
+		verify_proof_case(root, case.0, case.1);
+	}
+}
+
+#[test]
+fn fails_invalid_proof() {
+	let root = "4c59b428da385567a6d42ee1881ecbe43cf30bf8c4499887b7c6f689d23d4672";
+	let invalid_leaf = "e56abc4f8308afe283b128761e3d00202aa3fa502526b317b37e114a5d52416e";
+	let leaf_hash = utils::hex_as_byte_array(invalid_leaf).unwrap();
+	let proofs = [
+		"e5c1cefc1be025a1f2851d1c21a1e4417fb89a8ac8a10d3655c915a514160c9d",
+		"beab672f1c4ec3b1851d054f8e9ecae5f45646d3c67398174cd4c6d0ae9e15d6",
+		"92379acb8de9c3999d5e34bb0c280ba3a7ea8a7fb92474099b9f05c1e5856b57",
+		"3ad35d31ebe6d14143f2401f2fa9d5816dc5cfb12c9041afbf1f653a381ba289",
+		"7af4325e3a2a279b581ba9877800c1ef77e9f8208b8750b3dd46c7848f337491",
+		"c2d3826ca7c9ed3c53e4757e5b222083f985f07109c800d5e4090dca8cb94779",
+		"5e23727864ebad198df2f497cb3e74455f280dad3c92c3b368bddd91dafd48ec",
+		"703ad3a90417ac11be663bd45122ef7bb139e2ccde51889c1c3922c93e78f8b7",
+		"335fb756d0b76f5ddba80a4238ad8b19e2fda8e620de8fc8eeabef08e53c8c1c",
+		"ab12930064ec318bb8501d88670d659da956a1cdb30cbf7033f561d6368c40e9",
+	]
+	.into_iter()
+	.map(|h| {
+		let bytes: [u8; 32] = utils::hex_as_byte_array(h).unwrap();
+		bytes
+	})
+	.collect::<Vec<[u8; 32]>>();
+	let proof_root = proof_root(leaf_hash, proofs);
+	assert_ne!(root, hex::encode(proof_root));
+}
+
+#[test]
+fn test_sort_array() {
+	let arr1 = [0u8; 32];
+	let arr2 = [0u8; 32];
+	let result = sort_array(arr1, arr2, 0 as usize);
+	assert_eq!(result, [arr1, arr2].concat());
+
+	let arr1 = [0u8; 32];
+	let arr2 = [1u8; 32];
+	let result = sort_array(arr1, arr2, 0 as usize);
+	assert_eq!(result, [arr1, arr2].concat());
+
+	let arr1 = [2u8; 32];
+	let arr2 = [0u8; 32];
+	let result = sort_array(arr1, arr2, 0 as usize);
+	assert_eq!(result, [arr2, arr1].concat());
+}
+
+pub fn verify_proof_case(root: &str, leaf: &str, proofs: Vec<&str>) {
+	let leaf_hash = utils::hex_as_byte_array(leaf).unwrap();
+
+	let proofs = proofs
+		.into_iter()
+		.map(|h| {
+			let bytes = utils::hex_as_byte_array(h).unwrap();
+			bytes
+		})
+		.collect::<Vec<[u8; 32]>>();
+	let proof_root = proof_root(leaf_hash, proofs);
+	assert_eq!(root, hex::encode(proof_root));
+}

--- a/pallets/airdrop/src/tests/mock.rs
+++ b/pallets/airdrop/src/tests/mock.rs
@@ -1,0 +1,123 @@
+use crate::{self as pallet_airdrop, types};
+use core::marker::PhantomData;
+
+use frame_support::{parameter_types, traits::ConstU32};
+use frame_system as system;
+use pallet_balances;
+use sp_core::H256;
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+type Balance = u128;
+type Index = u64;
+type BlockNumber = u64;
+
+pub struct TestValidator<T>(PhantomData<T>);
+
+impl types::MerkelProofValidator<Test> for TestValidator<Test> {
+	fn validate(
+		_root_hash: pallet_airdrop::types::MerkleHash,
+		_leaf_hash: pallet_airdrop::types::MerkleHash,
+		_proofs: pallet_airdrop::types::MerkleProofs<Test>,
+	) -> bool {
+		return true;
+	}
+}
+
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		AirdropModule: pallet_airdrop::{Pallet, Call, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Vesting: pallet_vesting::{Pallet, Call, Storage, Event<T>, Config<T>},
+	}
+);
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const SS58Prefix: u8 = 42;
+}
+
+impl system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Origin = Origin;
+	type Call = Call;
+	type Index = Index;
+	type BlockNumber = BlockNumber;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = sp_core::sr25519::Public;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: u128 = 500;
+	pub const MaxLocks: u32 = 50;
+	pub const VestingMinTransfer: Balance = 10_000;
+}
+
+impl pallet_airdrop::Config for Test {
+	type Event = Event;
+	type Currency = Balances;
+	type BalanceTypeConversion = sp_runtime::traits::ConvertInto;
+	type AirdropWeightInfo = pallet_airdrop::weights::AirDropWeightInfo<Test>;
+	type MerkelProofValidator = TestValidator<Test>;
+	type MaxProofSize = ConstU32<10>;
+
+	const AIRDROP_VARIABLES: types::AirdropBehaviour = types::AirdropBehaviour {
+		defi_instant_percentage: 40,
+		non_defi_instant_percentage: 30,
+		vesting_period: 5_256_000,
+	};
+}
+
+impl pallet_balances::Config for Test {
+	type MaxLocks = MaxLocks;
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type Balance = Balance;
+	type Event = Event;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+}
+
+impl pallet_vesting::Config for Test {
+	type Event = Event;
+	type Currency = <Test as pallet_airdrop::Config>::Currency;
+	type BlockNumberToBalance = sp_runtime::traits::ConvertInto;
+	type MinVestedTransfer = VestingMinTransfer;
+	type WeightInfo = ();
+	const MAX_VESTING_SCHEDULES: u32 = 10;
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap()
+		.into()
+}

--- a/pallets/airdrop/src/tests/mod.rs
+++ b/pallets/airdrop/src/tests/mod.rs
@@ -115,7 +115,6 @@ pub fn minimal_test_ext() -> sp_io::TestExternalities {
 	let account_id = types::AccountIdOf::<Test>::decode(&mut &account_hex[..]).unwrap();
 	pallet_airdrop::GenesisConfig::<Test> {
 		creditor_account: account_id,
-		exchange_accounts: vec![],
 		merkle_root: hex!["4c59b428da385567a6d42ee1881ecbe43cf30bf8c4499887b7c6f689d23d4672"],
 	}
 	.assimilate_storage(&mut t)

--- a/pallets/airdrop/src/tests/mod.rs
+++ b/pallets/airdrop/src/tests/mod.rs
@@ -1,0 +1,211 @@
+mod exchange_claim;
+mod merkle_tests;
+pub mod mock;
+mod signature_validation;
+mod user_claim;
+mod utility_functions;
+pub mod prelude {
+	pub use super::{
+		force_get_creditor_account, get_last_event, minimal_test_ext, mock, run_to_block, samples,
+		set_creditor_balance, tranfer_to_creditor,
+	};
+	pub use crate as pallet_airdrop;
+	pub use crate::tests;
+	pub use codec::Encode;
+	pub use frame_support::{
+		assert_err, assert_err_ignore_postinfo, assert_err_with_weight, assert_noop, assert_ok,
+		assert_storage_noop,
+	};
+	pub use hex_literal::hex as decode_hex;
+	pub use mock::{AirdropModule, Origin, Test};
+	pub use pallet_airdrop::{types, utils};
+	pub use sp_core::bytes;
+	pub use sp_runtime::traits::{Bounded, IdentifyAccount, Saturating};
+
+	pub type PalletError = pallet_airdrop::Error<Test>;
+	pub type PalletEvent = pallet_airdrop::Event<Test>;
+	pub type PalletCall = pallet_airdrop::Call<Test>;
+	pub type BalanceError = pallet_balances::Error<Test>;
+}
+
+use frame_support::{traits::ConstU32, BoundedVec};
+use mock::System;
+use prelude::*;
+
+#[derive(Clone)]
+pub struct UserClaimTestCase {
+	pub icon_address: [u8; 20],
+	pub ice_address: types::IceAddress,
+	pub message: types::RawPayload,
+	pub icon_signature: [u8; 65],
+	pub ice_signature: [u8; 64],
+	pub amount: u128,
+	pub defi_user: bool,
+	pub merkle_proofs: BoundedVec<types::MerkleHash, ConstU32<10>>,
+	pub merkle_root: [u8; 32],
+}
+
+impl Default for UserClaimTestCase {
+	fn default() -> Self {
+		let (root, proofs) = to_test_case(samples::MERKLE_PROOF_SAMPLE);
+		let bounded_proofs =
+			BoundedVec::<types::MerkleHash, ConstU32<10>>::try_from(proofs).unwrap();
+		Self {
+			icon_address: samples::VALID_ICON_WALLET,
+			ice_address: samples::VALID_ICE_ADDRESS,
+			message: samples::VALID_MESSAGE,
+			icon_signature: samples::VALID_ICON_SIGNATURE,
+			ice_signature: samples::VALID_ICE_SIGNATURE,
+			amount: 12_000_000,
+			defi_user: true,
+			merkle_proofs: bounded_proofs,
+			merkle_root: root,
+		}
+	}
+}
+
+pub mod samples {
+
+	use super::decode_hex;
+	use super::types::{IconAddress, IconSignature, RawPayload};
+	use sp_core::sr25519;
+
+	pub const ACCOUNT_ID: &[sr25519::Public] = &[
+		sr25519::Public([1; 32]),
+		sr25519::Public([2; 32]),
+		sr25519::Public([3; 32]),
+		sr25519::Public([4; 32]),
+		sr25519::Public([5; 32]),
+	];
+
+	pub const ICON_ADDRESS: &[IconAddress] = &[
+		decode_hex!("ee1448f0867b90e6589289a4b9c06ac4516a75a9"),
+		decode_hex!("ee33286f367b90e6589289a4b987a6c4516a753a"),
+		decode_hex!("ee12463586abb90e6589289a4b9c06ac4516a7ba"),
+		decode_hex!("ee02363546bcc50e643910104321c0623451a65a"),
+	];
+
+	pub const MERKLE_PROOF_SAMPLE: (&str, &[&str]) = (
+		"7fe522d63ebcabfa052eec3647366138c23c9870995f4af94d9b22b8c5923f49",
+		&[
+			"813340daefd7f1ca705faf8318cf6455632259d113c06e97b70eeeccd43519a9",
+			"409519ab7129397bdc895e4da05871c9725697a5e092addf2fe90f6e795feb8f",
+			"38055bb872670c69ac3461707f8c0b4b8e436eecfc84cfd80db30db3030c489a",
+		],
+	);
+
+	pub const VALID_ICON_SIGNATURE:IconSignature = decode_hex!("9ee3f663175691ad82f4fbb0cfd0594652e3a034e3b6934b0e4d4a60437ba4043c89d2ffcb7b0af49ed0744ce773612d7ebcdf3a5b035c247706050e0a0033e401");
+	pub const VALID_MESSAGE: RawPayload = *b"icx_sendTransaction.data.{method.transfer.params.{wallet.b6e7a79d04e11a2dd43399f677878522523327cae2691b6cd1eb972b5a88eb48}}.dataType.call.from.hxb48f3bd3862d4a489fb3c9b761c4cfb20b34a645.nid.0x1.nonce.0x1.stepLimit.0x0.timestamp.0x0.to.hxb48f3bd3862d4a489fb3c9b761c4cfb20b34a645.version.0x3";
+	pub const VALID_ICON_WALLET: IconAddress =
+		decode_hex!("b48f3bd3862d4a489fb3c9b761c4cfb20b34a645");
+	pub const VALID_ICE_ADDRESS: [u8; 32] =
+		decode_hex!("b6e7a79d04e11a2dd43399f677878522523327cae2691b6cd1eb972b5a88eb48");
+	pub const VALID_ICE_SIGNATURE : [u8;64] =decode_hex!("901bda07fb98882a4944f50925b45d041a8a05751a45501eab779416bb55ca5537276dad3c68627a7ddb96956a17ae0d89ca27901a9638ad26426d0e2fbf7e8a");
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn minimal_test_ext() -> sp_io::TestExternalities {
+	use codec::Decode;
+	use frame_support::traits::GenesisBuild;
+	use hex_literal::hex;
+	let mut t = frame_system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap();
+	let account_hex = hex!["d893ef775b5689473b2e9fa32c1f15c72a7c4c86f05f03ee32b8aca6ce61b92c"];
+	let account_id = types::AccountIdOf::<Test>::decode(&mut &account_hex[..]).unwrap();
+	pallet_airdrop::GenesisConfig::<Test> {
+		creditor_account: account_id,
+		exchange_accounts: vec![],
+		merkle_root: hex!["4c59b428da385567a6d42ee1881ecbe43cf30bf8c4499887b7c6f689d23d4672"],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+	t.into()
+}
+
+pub fn run_to_block(n: types::BlockNumberOf<Test>) {
+	use frame_support::traits::Hooks;
+
+	while System::block_number() < n {
+		if System::block_number() > 1 {
+			AirdropModule::on_finalize(System::block_number());
+			System::on_finalize(System::block_number());
+		}
+		System::set_block_number(System::block_number() + 1);
+
+		System::on_initialize(System::block_number());
+		AirdropModule::on_initialize(System::block_number());
+	}
+}
+
+pub fn get_last_event() -> Option<<Test as frame_system::Config>::Event> {
+	<frame_system::Pallet<Test>>::events()
+		.pop()
+		.map(|v| v.event)
+}
+
+pub fn set_creditor_balance(balance: u64) {
+	let creditor_account = force_get_creditor_account::<Test>();
+	let deposit_res = <Test as pallet_airdrop::Config>::Currency::set_balance(
+		mock::Origin::root(),
+		creditor_account,
+		balance.into(),
+		0u32.into(),
+	);
+
+	assert_ok!(deposit_res);
+	assert_eq!(
+		<Test as pallet_airdrop::Config>::Currency::free_balance(&creditor_account),
+		balance.into()
+	);
+}
+
+pub fn to_test_case(
+	sample: (&str, &'static [&str]),
+) -> (types::MerkleHash, Vec<types::MerkleHash>) {
+	let mut hash_bytes = [0u8; 32];
+	hex::decode_to_slice(sample.0, &mut hash_bytes as &mut [u8]).unwrap();
+	let proofs = sample
+		.1
+		.iter()
+		.map(|p| {
+			let mut bytes: [u8; 32] = [0u8; 32];
+			hex::decode_to_slice(p, &mut bytes as &mut [u8]).unwrap();
+			bytes
+		})
+		.collect();
+
+	(hash_bytes, proofs)
+}
+
+pub fn tranfer_to_creditor(sponser: &types::AccountIdOf<Test>, amount: types::BalanceOf<Test>) {
+	assert_ok!(<Test as pallet_airdrop::Config>::Currency::transfer(
+		Origin::signed(sponser.clone()),
+		force_get_creditor_account::<Test>(),
+		amount,
+	));
+}
+
+pub fn force_get_creditor_account<T: pallet_airdrop::Config>() -> types::AccountIdOf<T> {
+	pallet_airdrop::Pallet::<T>::get_creditor_account().expect("creditor account not set")
+}
+
+impl Default for types::SnapshotInfo<Test> {
+	fn default() -> Self {
+		Self::new(
+			types::AccountIdOf::<Test>::from_raw([0u8; 32]),
+			false,
+			0u32.into(),
+		)
+	}
+}
+
+impl<T> types::SnapshotInfo<T>
+where
+	T: pallet_airdrop::Config,
+{
+	pub fn ice_address(mut self, val: types::AccountIdOf<T>) -> Self {
+		self.ice_address = val;
+		self
+	}
+}

--- a/pallets/airdrop/src/tests/signature_validation.rs
+++ b/pallets/airdrop/src/tests/signature_validation.rs
@@ -1,0 +1,75 @@
+use super::prelude::*;
+use hex_literal::hex;
+
+const VALID_ICON_SIGNATURE: types::IconSignature = hex!("9ee3f663175691ad82f4fbb0cfd0594652e3a034e3b6934b0e4d4a60437ba4043c89d2ffcb7b0af49ed0744ce773612d7ebcdf3a5b035c247706050e0a0033e401");
+const VALID_MESSAGE: &str = "icx_sendTransaction.data.{method.transfer.params.{wallet.b6e7a79d04e11a2dd43399f677878522523327cae2691b6cd1eb972b5a88eb48}}.dataType.call.from.hxb48f3bd3862d4a489fb3c9b761c4cfb20b34a645.nid.0x1.nonce.0x1.stepLimit.0x0.timestamp.0x0.to.hxb48f3bd3862d4a489fb3c9b761c4cfb20b34a645.version.0x3";
+const VALID_ICON_WALLET: types::IconAddress =
+	decode_hex!("b48f3bd3862d4a489fb3c9b761c4cfb20b34a645");
+
+#[test]
+fn test_ice_signature_native() {
+	let ice_bytes = hex!("741c08a06f41c596608f6774259bd9043304adfa5d3eea62760bd9be97634d63");
+	let signature =hex!("e8dda773f806311db1937816ed5dc9d9051b30fe18e1feb0bbed2dd17cb58960e2787b2c4c725d61d25e08b4fc8be5eac5e3b553e0eaf398fc4e66220e71bb87");
+	let message =hex!("2f8c6129d816cf51c374bc7f08c3e63ed156cf78aefb4a6550d97b87997977ee00000000000000000200d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a4500000000000000");
+	let result = AirdropModule::check_signature(&signature, &message, &ice_bytes);
+
+	assert!(result);
+}
+
+#[test]
+fn test_ice_signature_frontend_plain_message() {
+	let ice_bytes = hex!("14524435eb22c05c20e773cb6298886961d632f3ec29f4e4245b02710da2a22f");
+	let signature =hex!("42b054d71be08205377b8f9fa1e96fbb45bfe8889d5cc8019e41ff6ea6364525669092b385920b38d7d289f312e63d9ea4d036e2989909926b5127417784eb83");
+	let message = "Message to Sign".as_bytes();
+	let wrapped_message = utils::wrap_bytes(message);
+	let result = AirdropModule::check_signature(&signature, &wrapped_message, &ice_bytes);
+
+	assert!(result);
+}
+
+#[test]
+fn test_ice_signature_frontend_icon_signature() {
+	let ice_bytes = hex!("14524435eb22c05c20e773cb6298886961d632f3ec29f4e4245b02710da2a22f");
+
+	let signature =hex!("62ff224a8401451ffd32e8d56bef2253ecebdf9d5fa825ccd2de823ccebad34cdf18ea924273cd1e735ca1a0ec8a4b2a61333bc0ec8d0a1f6ff08d8cf25a9080");
+	let message =  hex!("11f7dc15685555af583228f14e6f5766cf339d3c38389ce022f10a468296dde864df99d9056b7ee7116a290713ba38c7ca7fcf161fc8137a039445d0701c4dbb00");
+	let wrapped_message = utils::wrap_bytes(&message);
+	let result = AirdropModule::check_signature(&signature, &wrapped_message, &ice_bytes);
+
+	assert!(result);
+
+	assert!(result);
+}
+
+#[test]
+fn test_ice_signature_frontend_icon_signature_2() {
+	let _icon_address = hex!("b48f3bd3862d4a489fb3c9b761c4cfb20b34a645");
+	let ice_bytes = hex!("b6e7a79d04e11a2dd43399f677878522523327cae2691b6cd1eb972b5a88eb48");
+
+	let ice_signature =hex!("901bda07fb98882a4944f50925b45d041a8a05751a45501eab779416bb55ca5537276dad3c68627a7ddb96956a17ae0d89ca27901a9638ad26426d0e2fbf7e8a");
+	let icon_signature =  hex!("9ee3f663175691ad82f4fbb0cfd0594652e3a034e3b6934b0e4d4a60437ba4043c89d2ffcb7b0af49ed0744ce773612d7ebcdf3a5b035c247706050e0a0033e401");
+	let wrapped_message = utils::wrap_bytes(&icon_signature);
+
+	let result = AirdropModule::check_signature(&ice_signature, &wrapped_message, &ice_bytes);
+
+	assert!(result);
+}
+
+#[test]
+fn test_ice_signature_polkadot() {
+	let ice_bytes = hex!("8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48");
+	let signature =hex!("2aeaa98e26062cf65161c68c5cb7aa31ca050cb5bdd07abc80a475d2a2eebc7b7a9c9546fbdff971b29419ddd9982bf4148c81a49df550154e1674a6b58bac84");
+	let message = "This is a text message".as_bytes();
+	let result = AirdropModule::check_signature(&signature, &message, &ice_bytes);
+
+	assert!(result);
+}
+
+#[test]
+fn recover_icon_address() {
+	let signature = VALID_ICON_SIGNATURE.clone();
+	let message = VALID_MESSAGE.as_bytes();
+	let icon_address = VALID_ICON_WALLET.to_vec();
+	let extracted_address = utils::recover_address(&signature, message).unwrap();
+	assert_eq!(icon_address, extracted_address);
+}

--- a/pallets/airdrop/src/tests/user_claim.rs
+++ b/pallets/airdrop/src/tests/user_claim.rs
@@ -1,0 +1,419 @@
+use super::prelude::*;
+use crate::tests::UserClaimTestCase;
+use frame_support::traits::{Currency, LockableCurrency, ReservableCurrency};
+
+#[test]
+fn claim_success() {
+	let ofw_account = samples::ACCOUNT_ID[0].into_account();
+	let mut test_ext = minimal_test_ext();
+	test_ext.execute_with(|| {
+		assert_ok!(AirdropModule::set_airdrop_server_account(
+			Origin::root(),
+			ofw_account
+		));
+		let mut case = UserClaimTestCase::default();
+		case.amount = 12_017_332_u64.into();
+
+		set_creditor_balance(10_000_0000);
+
+		assert_ok!(AirdropModule::dispatch_user_claim(
+			Origin::signed(AirdropModule::get_airdrop_server_account().unwrap()),
+			case.icon_address,
+			case.ice_address,
+			case.message,
+			case.icon_signature,
+			case.ice_signature,
+			case.amount,
+			case.defi_user,
+			case.merkle_proofs,
+		));
+		let ice_account = AirdropModule::to_account_id(case.ice_address.clone()).unwrap();
+		let claim_balance = <Test as pallet_airdrop::Config>::Currency::usable_balance(ice_account);
+
+		#[cfg(not(feature = "no-vesting"))]
+		assert_eq!(claim_balance, 6761333);
+
+		#[cfg(feature = "no-vesting")]
+		assert_eq!(claim_balance, case.amount);
+
+		let snapshot = <pallet_airdrop::IconSnapshotMap<Test>>::get(&case.icon_address).unwrap();
+
+		let mapped_icon_wallet = AirdropModule::get_ice_to_icon_map(&ice_account);
+		assert_eq!(mapped_icon_wallet, Some(case.icon_address));
+
+		assert_eq!(snapshot.done_instant, true);
+		#[cfg(not(feature = "no-vesting"))]
+		assert_eq!(snapshot.done_vesting, true);
+	});
+}
+
+#[test]
+fn insufficient_balance() {
+	let ofw_account = samples::ACCOUNT_ID[0].into_account();
+	let mut test_ext = minimal_test_ext();
+	test_ext.execute_with(|| {
+		assert_ok!(AirdropModule::set_airdrop_server_account(
+			Origin::root(),
+			ofw_account
+		));
+
+		let mut case = UserClaimTestCase::default();
+		case.amount = 10017332_u64.into();
+		let creditor_account = force_get_creditor_account::<Test>();
+		<Test as pallet_airdrop::Config>::Currency::set_balance(
+			mock::Origin::root(),
+			creditor_account,
+			10_u32.into(),
+			10_u32.into(),
+		)
+		.unwrap();
+
+		assert_err!(
+			AirdropModule::dispatch_user_claim(
+				Origin::signed(AirdropModule::get_airdrop_server_account().unwrap()),
+				case.icon_address,
+				case.ice_address.clone(),
+				case.message,
+				case.icon_signature,
+				case.ice_signature,
+				case.amount,
+				case.defi_user,
+				case.merkle_proofs
+			),
+			PalletError::InsufficientCreditorBalance
+		);
+	});
+}
+
+#[test]
+fn already_claimed() {
+	let ofw_account = samples::ACCOUNT_ID[0].into_account();
+	let mut test_ext = minimal_test_ext();
+	test_ext.execute_with(|| {
+		assert_ok!(AirdropModule::set_airdrop_server_account(
+			Origin::root(),
+			ofw_account
+		));
+		let mut case = UserClaimTestCase::default();
+		let ice_account = AirdropModule::to_account_id(case.ice_address).unwrap();
+		case.amount = 10017332_u64.into();
+
+		let mut snapshot = types::SnapshotInfo::default().ice_address(ice_account.clone());
+		snapshot.done_instant = true;
+		snapshot.done_vesting = true;
+
+		pallet_airdrop::IconSnapshotMap::<Test>::insert(&case.icon_address, snapshot);
+		let creditor_account = force_get_creditor_account::<Test>();
+
+		<Test as pallet_airdrop::Config>::Currency::set_balance(
+			mock::Origin::root(),
+			creditor_account,
+			10_000_0000_u32.into(),
+			10_000_00_u32.into(),
+		)
+		.unwrap();
+
+		assert_err!(
+			AirdropModule::dispatch_user_claim(
+				Origin::signed(AirdropModule::get_airdrop_server_account().unwrap()),
+				case.icon_address,
+				case.ice_address.clone(),
+				case.message,
+				case.icon_signature,
+				case.ice_signature,
+				case.amount,
+				case.defi_user,
+				case.merkle_proofs
+			),
+			PalletError::ClaimAlreadyMade
+		);
+	});
+}
+
+#[test]
+fn invalid_payload() {
+	let ofw_account = samples::ACCOUNT_ID[0].into_account();
+	let mut test_ext = minimal_test_ext();
+	test_ext.execute_with(|| {
+        assert_ok!(AirdropModule::set_airdrop_server_account(
+			Origin::root(),
+			ofw_account
+		));
+		let mut case =UserClaimTestCase::default();
+
+		case.message = *b"icx_sendTransaction.data.{method.transfer.params.{wallet.eee7a79d04e11a2dd43399f677878522523327cae2691b6cd1eb972b5a88eb48}}.dataType.call.from.hxb48f3bd3862d4a489fb3c9b761c4cfb20b34a645.nid.0x1.nonce.0x1.stepLimit.0x0.timestamp.0x0.to.hxb48f3bd3862d4a489fb3c9b761c4cfb20b34a645.version.0x3";
+		let creditor_account = force_get_creditor_account::<Test>();
+
+		<Test as pallet_airdrop::Config>::Currency::set_balance(
+			mock::Origin::root(),
+			creditor_account,
+			10_000_0000_u32.into(),
+			10_000_00_u32.into(),
+		)
+		.unwrap();
+
+		assert_err!(
+			AirdropModule::dispatch_user_claim(
+				Origin::signed(AirdropModule::get_airdrop_server_account().unwrap()),
+				case.icon_address,
+				case.ice_address.clone(),
+				case.message,
+				case.icon_signature,
+				case.ice_signature,
+				case.amount,
+				case.defi_user,
+				case.merkle_proofs
+			),
+			PalletError::InvalidMessagePayload
+		);
+	});
+}
+
+#[test]
+fn invalid_ice_signature() {
+	let ofw_account = samples::ACCOUNT_ID[0].into_account();
+	let mut test_ext = minimal_test_ext();
+	test_ext.execute_with(|| {
+		assert_ok!(AirdropModule::set_airdrop_server_account(
+			Origin::root(),
+			ofw_account
+		));
+		let mut case = UserClaimTestCase::default();
+		case.ice_signature = [0u8; 64];
+
+		let creditor_account = force_get_creditor_account::<Test>();
+		<Test as pallet_airdrop::Config>::Currency::set_balance(
+			mock::Origin::root(),
+			creditor_account,
+			10_000_0000_u32.into(),
+			10_000_00_u32.into(),
+		)
+		.unwrap();
+
+		assert_err!(
+			AirdropModule::dispatch_user_claim(
+				Origin::signed(AirdropModule::get_airdrop_server_account().unwrap()),
+				case.icon_address,
+				case.ice_address.clone(),
+				case.message,
+				case.icon_signature,
+				case.ice_signature,
+				case.amount,
+				case.defi_user,
+				case.merkle_proofs
+			),
+			PalletError::InvalidIceSignature
+		);
+	});
+}
+
+#[test]
+fn invalid_icon_signature() {
+	let ofw_account = samples::ACCOUNT_ID[0].into_account();
+	let mut test_ext = minimal_test_ext();
+	test_ext.execute_with(|| {
+		assert_ok!(AirdropModule::set_airdrop_server_account(
+			Origin::root(),
+			ofw_account
+		));
+		let mut case = UserClaimTestCase::default();
+		case.icon_signature = [0u8; 65];
+
+		let creditor_account = force_get_creditor_account::<Test>();
+		<Test as pallet_airdrop::Config>::Currency::set_balance(
+			mock::Origin::root(),
+			creditor_account,
+			10_000_0000_u32.into(),
+			10_000_00_u32.into(),
+		)
+		.unwrap();
+
+		assert_err!(
+			AirdropModule::dispatch_user_claim(
+				Origin::signed(AirdropModule::get_airdrop_server_account().unwrap()),
+				case.icon_address,
+				case.ice_address.clone(),
+				case.message,
+				case.icon_signature,
+				case.ice_signature,
+				case.amount,
+				case.defi_user,
+				case.merkle_proofs
+			),
+			PalletError::InvalidSignature
+		);
+	});
+}
+
+#[test]
+#[cfg(not(feature = "no-vesting"))]
+fn respect_vesting_pallet_min_transfer() {
+	use types::DoTransfer;
+	type MakeTransfer = pallet_airdrop::vested_transfer::DoVestdTransfer;
+
+	minimal_test_ext().execute_with(|| {
+		set_creditor_balance(10_000_000);
+		run_to_block(4);
+		let is_defi_user = false;
+		let ice_address = samples::ACCOUNT_ID[1];
+		let icon_address = samples::ICON_ADDRESS[1];
+
+		// We intentionally make it less than crate::tests::mock::MinVestingTransfer
+		let total_amount = 9_555;
+		assert!(total_amount < crate::tests::mock::VestingMinTransfer::get());
+
+		let mut snapshot =
+			types::SnapshotInfo::<Test>::new(ice_address, is_defi_user, total_amount);
+
+		let transfer_res = MakeTransfer::do_transfer::<Test>(&mut snapshot);
+
+		assert_ok!(transfer_res);
+		assert!(snapshot.done_vesting);
+		assert!(snapshot.done_instant);
+		assert_eq!(
+			total_amount,
+			<Test as pallet_airdrop::Config>::Currency::total_balance(&ice_address)
+		);
+
+		// vesting amount derived from given total_amount will alwayd be less
+		// than pallet_vesting::Config::vestingMinTransfer in this case
+		// that means everything was transferred as instant amount
+		// this means snapshot.vesting_block_number should not have been set
+		assert_eq!(None, snapshot.vesting_block_number);
+	});
+}
+
+#[test]
+fn partail_transfer_can_reclaim() {
+	let get_per = utils::get_instant_percentage::<Test>;
+	minimal_test_ext().execute_with(|| {
+		// We are at block 1 now
+		run_to_block(1);
+
+		let mut case = UserClaimTestCase::default();
+		case.amount = 10_u64.pow(18).into();
+		let ice_account = AirdropModule::to_account_id(case.ice_address.clone()).unwrap();
+		set_creditor_balance(Bounded::max_value());
+
+		let mut user_balance =
+			<Test as pallet_airdrop::Config>::Currency::total_balance(&ice_account);
+		assert_eq!(user_balance, 0u32.into());
+
+		#[cfg(feature = "no-vesting")]
+		let (instant_amount, vesting_amount) = (case.amount, 0u128);
+
+		#[cfg(not(feature = "no-vesting"))]
+		let (instant_amount, vesting_amount) = {
+			let (raw_instant, raw_vesting) =
+				utils::get_splitted_amounts::<Test>(case.amount, get_per(case.defi_user)).unwrap();
+			let (schedule, rem) = utils::new_vesting_with_deadline::<
+				Test,
+				{ crate::vested_transfer::VESTING_APPLICABLE_FROM },
+			>(raw_vesting, crate::vested_transfer::BLOCKS_IN_YEAR.into());
+
+			(raw_instant + rem, schedule.unwrap().locked())
+		};
+
+		// Eat all vesting slots so next vesting will fail
+		{
+			let vesting_count_limit = <Test as pallet_vesting::Config>::MAX_VESTING_SCHEDULES;
+			let mut amount_consumed = 0;
+			for i in 0..vesting_count_limit {
+				let res = pallet_vesting::Pallet::<Test>::vested_transfer(
+					Origin::signed(force_get_creditor_account::<Test>()),
+					ice_account.clone(),
+					types::VestingInfoOf::<Test>::new(10_000, 2000, 5),
+				)
+				.map(|_| i);
+				assert_eq!(res, Ok(i));
+				amount_consumed += 10_000;
+			}
+
+			let new_balance =
+				<Test as pallet_airdrop::Config>::Currency::total_balance(&ice_account);
+			assert_eq!(new_balance, user_balance + amount_consumed);
+			user_balance = new_balance;
+		}
+
+		// Try to claim in first attempt.
+		// It will only let instant transfer to pass
+		{
+			let case = case.clone();
+			assert_ok!(AirdropModule::dispatch_user_claim(
+				Origin::root(),
+				case.icon_address,
+				case.ice_address,
+				case.message,
+				case.icon_signature,
+				case.ice_signature,
+				case.amount,
+				case.defi_user,
+				case.merkle_proofs,
+			));
+
+			let snapshot = AirdropModule::get_icon_snapshot_map(&case.icon_address).unwrap();
+			let mapped_icon_wallet = AirdropModule::get_ice_to_icon_map(&ice_account);
+			let new_balance =
+				<Test as pallet_airdrop::Config>::Currency::total_balance(&ice_account);
+			assert_eq!(true, snapshot.done_instant);
+			assert_eq!(false, snapshot.done_vesting);
+			assert_eq!(mapped_icon_wallet.as_ref(), Some(&case.icon_address));
+			assert_eq!(new_balance, user_balance + instant_amount);
+
+			user_balance = new_balance;
+		}
+
+		// Release the streames vesting schedules put previously
+		{
+			run_to_block(12);
+			assert_ok!(pallet_vesting::Pallet::<Test>::vest(Origin::signed(
+				ice_account.clone()
+			)));
+		}
+
+		// Try to claim again
+		#[cfg(not(feature = "no-vesting"))]
+		{
+			assert_ok!(AirdropModule::dispatch_user_claim(
+				Origin::root(),
+				case.icon_address,
+				case.ice_address,
+				case.message,
+				case.icon_signature,
+				case.ice_signature,
+				case.amount,
+				case.defi_user,
+				case.merkle_proofs,
+			));
+
+			let snapshot = AirdropModule::get_icon_snapshot_map(&case.icon_address).unwrap();
+			let mapped_icon_wallet = AirdropModule::get_ice_to_icon_map(&ice_account);
+			let new_balance =
+				<Test as pallet_airdrop::Config>::Currency::total_balance(&ice_account);
+			assert_eq!(true, snapshot.done_instant);
+			assert_eq!(true, snapshot.done_vesting);
+			assert_eq!(Some(1), snapshot.instant_block_number);
+			assert_eq!(Some(12), snapshot.vesting_block_number);
+			assert_eq!(mapped_icon_wallet.as_ref(), Some(&case.icon_address));
+			assert_eq!(new_balance, user_balance + vesting_amount);
+		}
+
+		#[cfg(feature = "no-vesting")]
+		{
+			assert_noop!(
+				AirdropModule::dispatch_user_claim(
+					Origin::root(),
+					case.icon_address,
+					case.ice_address,
+					case.message,
+					case.icon_signature,
+					case.ice_signature,
+					case.amount,
+					case.defi_user,
+					case.merkle_proofs,
+				),
+				PalletError::ClaimAlreadyMade
+			);
+		}
+	});
+}

--- a/pallets/airdrop/src/tests/utility_functions.rs
+++ b/pallets/airdrop/src/tests/utility_functions.rs
@@ -1,0 +1,611 @@
+use super::prelude::*;
+
+#[test]
+fn update_server_account() {
+	minimal_test_ext().execute_with(|| {
+		assert_noop!(
+			AirdropModule::set_airdrop_server_account(Origin::none(), samples::ACCOUNT_ID[1]),
+			PalletError::DeniedOperation
+		);
+
+		assert_noop!(
+			AirdropModule::set_airdrop_server_account(
+				Origin::signed(samples::ACCOUNT_ID[1]),
+				samples::ACCOUNT_ID[2]
+			),
+			PalletError::DeniedOperation
+		);
+
+		assert_ok!(AirdropModule::set_airdrop_server_account(
+			Origin::root(),
+			samples::ACCOUNT_ID[1]
+		));
+		assert_eq!(
+			Some(samples::ACCOUNT_ID[1]),
+			AirdropModule::get_airdrop_server_account()
+		);
+	});
+}
+
+#[test]
+fn ensure_root_or_server() {
+	minimal_test_ext().execute_with(|| {
+		use sp_runtime::DispatchError::BadOrigin;
+
+		// Set server account to be ACCOUNT_ID[0]
+		let server_account = samples::ACCOUNT_ID[0];
+		assert_ok!(AirdropModule::set_airdrop_server_account(
+			Origin::root(),
+			server_account.clone()
+		));
+
+		// root origin should pass
+		assert_ok!(AirdropModule::ensure_root_or_server(Origin::root()));
+
+		// Any signed other than server account should fail
+		assert_err!(
+			AirdropModule::ensure_root_or_server(Origin::signed(samples::ACCOUNT_ID[2])),
+			BadOrigin
+		);
+
+		// Unsigned origin should fail
+		assert_err!(
+			AirdropModule::ensure_root_or_server(Origin::none()),
+			BadOrigin
+		);
+
+		// Signed with server account should pass
+		assert_ok!(AirdropModule::ensure_root_or_server(Origin::signed(
+			server_account
+		)));
+	});
+}
+
+#[test]
+fn get_vesting_amounts_splitted() {
+	minimal_test_ext().execute_with(|| {
+		use sp_runtime::ArithmeticError;
+		let get_splitted_amounts: _ = utils::get_splitted_amounts::<Test>;
+		let defi_instant = utils::get_instant_percentage::<Test>(true);
+		let non_defi_instant = utils::get_instant_percentage::<Test>(false);
+
+		assert_err!(
+			get_splitted_amounts(types::ServerBalance::max_value(), defi_instant),
+			ArithmeticError::Overflow
+		);
+		assert_eq!(
+			Ok((0_u32.into(), 0_u32.into())),
+			get_splitted_amounts(0_u32.into(), defi_instant)
+		);
+
+		assert_eq!(
+			Ok((900_u32.into(), 2100_u32.into())),
+			get_splitted_amounts(3_000_u32.into(), non_defi_instant)
+		);
+		assert_eq!(
+			Ok((1200_u32.into(), 1800_u32.into())),
+			get_splitted_amounts(3_000_u32.into(), defi_instant)
+		);
+
+		assert_eq!(
+			Ok((0_u32.into(), 1_u32.into())),
+			get_splitted_amounts(1_u32.into(), non_defi_instant)
+		);
+		assert_eq!(
+			Ok((0_u32.into(), 1_u32.into())),
+			get_splitted_amounts(1_u32.into(), defi_instant)
+		);
+
+		assert_eq!(
+			Ok((2932538_u32.into(), 6842591_u32.into())),
+			get_splitted_amounts(9775129_u32.into(), non_defi_instant)
+		);
+		assert_eq!(
+			Ok((3910051_u32.into(), 5865078_u32.into())),
+			get_splitted_amounts(9775129_u32.into(), defi_instant)
+		);
+	});
+}
+
+#[test]
+fn cook_vesting_schedule() {
+	type BlockToBalance = <Test as pallet_vesting::Config>::BlockNumberToBalance;
+	minimal_test_ext().execute_with(|| {
+		{
+			let (schedule, remainder) =
+				utils::new_vesting_with_deadline::<Test, 0u32>(10u32.into(), 10u32.into());
+
+			let schedule = schedule.unwrap();
+			assert_eq!(remainder, 0u32.into());
+
+			assert_eq!(schedule.locked(), 10u32.into());
+			assert_eq!(schedule.per_block(), 1u32.into());
+			assert_eq!(
+				schedule.ending_block_as_balance::<BlockToBalance>(),
+				10u32.into()
+			);
+		}
+
+		{
+			let (schedule, remainder) =
+				utils::new_vesting_with_deadline::<Test, 0u32>(5u32.into(), 10u32.into());
+
+			assert_eq!(None, schedule);
+			assert_eq!(remainder, 5u32.into());
+		}
+
+		{
+			let (schedule, remainer) =
+				utils::new_vesting_with_deadline::<Test, 5u32>(12u32.into(), 10u32.into());
+
+			let primary = schedule.unwrap();
+			assert_eq!(remainer, 2u32.into());
+
+			assert_eq!(primary.locked(), 10u32.into());
+			assert_eq!(primary.per_block(), 2u32.into());
+			assert_eq!(
+				primary.ending_block_as_balance::<BlockToBalance>(),
+				10u32.into()
+			);
+		}
+
+		{
+			let (schedule, remainer) =
+				utils::new_vesting_with_deadline::<Test, 0u32>(16u32.into(), 10u32.into());
+
+			let schedule = schedule.unwrap();
+			assert_eq!(remainer, 6u32.into());
+
+			assert_eq!(schedule.locked(), 10u32.into());
+			assert_eq!(schedule.per_block(), 1u32.into());
+			assert_eq!(
+				schedule.ending_block_as_balance::<BlockToBalance>(),
+				10u32.into()
+			);
+		}
+
+		{
+			let (schedule, remainer) =
+				utils::new_vesting_with_deadline::<Test, 0u32>(3336553u32.into(), 10_000u32.into());
+
+			let schedule = schedule.unwrap();
+			assert_eq!(remainer, 6553u32.into());
+
+			assert_eq!(schedule.locked(), 3330000u32.into());
+			assert_eq!(schedule.per_block(), 333u32.into());
+			assert_eq!(
+				schedule.ending_block_as_balance::<BlockToBalance>(),
+				10_000u32.into()
+			);
+		}
+	});
+}
+
+#[test]
+#[cfg(not(feature = "no-vesting"))]
+fn making_vesting_transfer() {
+	let get_per: _ = utils::get_instant_percentage::<Test>;
+
+	minimal_test_ext().execute_with(|| {
+		run_to_block(3);
+		let defi_user = true;
+		let amount: types::BalanceOf<Test> = 9775129_u64.into();
+		let icon_address = samples::ICON_ADDRESS[0];
+		type Currency = <Test as pallet_airdrop::Config>::Currency;
+		// Fund creditor
+		set_creditor_balance(u64::MAX);
+
+		{
+			let claimer = samples::ACCOUNT_ID[1];
+			let mut snapshot = types::SnapshotInfo::<Test> {
+				done_instant: false,
+				done_vesting: false,
+				ice_address: claimer.clone().into(),
+				amount,
+				defi_user,
+				..Default::default()
+			};
+
+			assert_ok!(AirdropModule::do_transfer(&mut snapshot, &icon_address));
+
+			// Ensure all amount is being transferred
+			assert_eq!(9775129_u128, Currency::free_balance(&claimer));
+
+			// Make sure user is getting atleast of instant amount
+			// might get more due to vesting remainder
+			assert!(Currency::usable_balance(&claimer) >= 2932538_u32.into());
+
+			// Make sure flags are updated
+			assert!(snapshot.done_instant && snapshot.done_vesting);
+		}
+
+		// When instant transfer is true but not vesting
+		{
+			let claimer = samples::ACCOUNT_ID[2];
+			let mut snapshot = types::SnapshotInfo::<Test> {
+				done_instant: true,
+				done_vesting: false,
+				ice_address: claimer.clone().into(),
+				amount,
+				defi_user,
+				..Default::default()
+			};
+
+			assert_ok!(AirdropModule::do_transfer(&mut snapshot, &icon_address));
+
+			// Ensure amount only accounting to vesting is transfererd
+
+			let expected_transfer = {
+				let vesting_amount: types::VestingBalanceOf<Test> =
+					utils::get_splitted_amounts::<Test>(amount, get_per(defi_user))
+						.unwrap()
+						.1;
+				let schedule = utils::new_vesting_with_deadline::<Test, 1u32>(
+					vesting_amount,
+					5256000u32.into(),
+				)
+				.0
+				.unwrap();
+
+				schedule.locked()
+			};
+			let user_balance = Currency::free_balance(&claimer);
+			assert_eq!(expected_transfer, user_balance);
+
+			// Ensure flag is updated
+			assert!(snapshot.done_vesting && snapshot.done_instant);
+		}
+
+		// When vesting is true but not done_instant
+		{
+			let claimer = samples::ACCOUNT_ID[3];
+			let mut snapshot = types::SnapshotInfo::<Test> {
+				done_instant: false,
+				done_vesting: true,
+				ice_address: claimer.clone().into(),
+				amount,
+				defi_user,
+				..Default::default()
+			};
+
+			assert_ok!(AirdropModule::do_transfer(&mut snapshot, &icon_address));
+
+			// Ensure amount only accounting to instant is transferred
+			let expected_transfer = {
+				let (instant_amount, vesting_amount) =
+					utils::get_splitted_amounts::<Test>(amount, get_per(defi_user)).unwrap();
+				let remainder = utils::new_vesting_with_deadline::<Test, 1u32>(
+					vesting_amount,
+					5256000u32.into(),
+				)
+				.1;
+
+				instant_amount + remainder
+			};
+			let user_balance = Currency::free_balance(&claimer);
+
+			assert_eq!(expected_transfer, user_balance);
+
+			// Ensure flag is updated
+			assert!(snapshot.done_vesting && snapshot.done_instant);
+		}
+
+		// When both are false
+		// NOTE: such snapshot will not be passed in actual from complete_transfer
+		{
+			let claimer = samples::ACCOUNT_ID[4];
+			let mut snapshot = types::SnapshotInfo::<Test> {
+				done_instant: true,
+				done_vesting: true,
+				ice_address: claimer.clone().into(),
+				amount,
+				defi_user,
+				..Default::default()
+			};
+
+			assert_ok!(AirdropModule::do_transfer(&mut snapshot, &icon_address));
+
+			// Ensure amount only accounting to instant is transfererd
+			assert_eq!(0_u128, Currency::free_balance(&claimer));
+
+			// Ensure flag is updates
+			assert!(snapshot.done_vesting && snapshot.done_instant);
+		}
+	});
+}
+
+#[test]
+fn test_extract_address() {
+	let payload = "icx_sendTransaction.data.{method.transfer.params.{wallet.b6e7a79d04e11a2dd43399f677878522523327cae2691b6cd1eb972b5a88eb48}}.dataType.call.from.hxb48f3bd3862d4a489fb3c9b761c4cfb20b34a645.nid.0x1.nonce.0x1.stepLimit.0x0.timestamp.0x0.to.hxb48f3bd3862d4a489fb3c9b761c4cfb20b34a645.version.0x3".as_bytes();
+	let expected_address =
+		hex_literal::hex!("b6e7a79d04e11a2dd43399f677878522523327cae2691b6cd1eb972b5a88eb48");
+	let extracted_address = utils::extract_ice_address(payload, &expected_address).unwrap();
+	assert_eq!(extracted_address, expected_address);
+}
+
+#[test]
+fn respect_airdrop_state() {
+	// First verify thet initially everything is allowed
+	assert_eq!(
+		types::AirdropState::default(),
+		types::AirdropState {
+			block_claim_request: false,
+			block_exchange_request: false,
+		}
+	);
+
+	// Tests types::AirdropState::block_claim_request
+	minimal_test_ext().execute_with(|| {
+		// By default we shall allow it
+		assert_ok!(AirdropModule::ensure_user_claim_switch());
+
+		// Set the state to block incoming request
+		assert_ok!(AirdropModule::update_airdrop_state(
+			Origin::root(),
+			types::AirdropState {
+				block_exchange_request: false,
+				block_claim_request: true,
+			}
+		));
+
+		// Call the helper function
+		assert_err!(
+			AirdropModule::ensure_user_claim_switch(),
+			PalletError::NewClaimRequestBlocked
+		);
+
+		// Call the actual dispatchable
+		assert_err!(
+			AirdropModule::dispatch_user_claim(
+				Origin::root(),
+				Default::default(),
+				Default::default(),
+				[0; 289],
+				[0; 65],
+				[0; 64],
+				Default::default(),
+				Default::default(),
+				Default::default(),
+			),
+			PalletError::NewClaimRequestBlocked,
+		);
+	});
+
+	// Tests types::AirdropState::block_exchange_request
+	minimal_test_ext().execute_with(|| {
+		// By default we shall allow it
+		assert_ok!(AirdropModule::ensure_exchange_claim_switch());
+
+		// Set the state to block incoming request
+		assert_ok!(AirdropModule::update_airdrop_state(
+			Origin::root(),
+			types::AirdropState {
+				block_exchange_request: true,
+				block_claim_request: false,
+			}
+		));
+
+		// Call the helper function
+		assert_err!(
+			AirdropModule::ensure_exchange_claim_switch(),
+			PalletError::NewExchangeRequestBlocked
+		);
+
+		// Call teh actual dispatchable
+		assert_noop!(
+			AirdropModule::dispatch_exchange_claim(
+				Origin::root(),
+				Default::default(),
+				Default::default(),
+				Default::default(),
+				Default::default(),
+				Default::default(),
+			),
+			PalletError::NewExchangeRequestBlocked
+		);
+	})
+}
+
+#[test]
+fn validate_creditor_fund() {
+	use frame_support::traits::Currency;
+
+	minimal_test_ext().execute_with(|| {
+		let exestinsial_balance = <Test as pallet_airdrop::Config>::Currency::minimum_balance();
+		let donator = samples::ACCOUNT_ID[1];
+		<Test as pallet_airdrop::Config>::Currency::deposit_creating(&donator, u64::MAX.into());
+
+		// When creditor balance is empty.
+		{
+			assert_err!(
+				AirdropModule::validate_creditor_fund(10),
+				PalletError::InsufficientCreditorBalance
+			);
+		}
+
+		// When creditor balance is exactly same as exestinsial balance
+		{
+			tranfer_to_creditor(&donator, exestinsial_balance);
+			assert_err!(
+				AirdropModule::validate_creditor_fund(exestinsial_balance.try_into().unwrap()),
+				PalletError::InsufficientCreditorBalance,
+			);
+		}
+
+		// When all of creditor balance is required
+		{
+			tranfer_to_creditor(&donator, u32::MAX.into());
+			let required_balance = <Test as pallet_airdrop::Config>::Currency::free_balance(
+				&force_get_creditor_account::<Test>(),
+			);
+
+			assert_err!(
+				AirdropModule::validate_creditor_fund(required_balance.try_into().unwrap()),
+				PalletError::InsufficientCreditorBalance,
+			);
+		}
+
+		// When only a portion of balance is required
+		{
+			assert_ok!(AirdropModule::validate_creditor_fund(10_000_000),);
+		}
+	});
+}
+
+#[test]
+fn ensure_claimable_snapshot() {
+	minimal_test_ext().execute_with(|| {
+		// Fail when both are claimed
+		{
+			let snapshot = types::SnapshotInfo::<Test> {
+				done_instant: true,
+				done_vesting: true,
+				..Default::default()
+			};
+			assert_err!(
+				AirdropModule::ensure_claimable(&snapshot),
+				PalletError::ClaimAlreadyMade
+			);
+		}
+
+		// Pass when both are not done
+		{
+			let snapshot = types::SnapshotInfo::<Test> {
+				done_instant: false,
+				done_vesting: false,
+				..Default::default()
+			};
+			assert_ok!(AirdropModule::ensure_claimable(&snapshot));
+		}
+
+		// Pass when vesting is not claimed
+		{
+			let snapshot = types::SnapshotInfo::<Test> {
+				done_instant: false,
+				done_vesting: true,
+				..Default::default()
+			};
+			assert_ok!(AirdropModule::ensure_claimable(&snapshot));
+		}
+
+		// Pass when instant is not claimed
+		{
+			let snapshot = types::SnapshotInfo::<Test> {
+				done_instant: true,
+				done_vesting: false,
+				..Default::default()
+			};
+
+			#[cfg(not(feature = "no-vesting"))]
+			assert_ok!(AirdropModule::ensure_claimable(&snapshot));
+
+			#[cfg(feature = "no-vesting")]
+			assert_err!(
+				AirdropModule::ensure_claimable(&snapshot),
+				PalletError::ClaimAlreadyMade
+			);
+		}
+	});
+}
+
+#[test]
+fn insert_or_get_snapshot() {
+	use crate::{IceIconMap, IconSnapshotMap};
+
+	// When there is previous record of this ice address
+	// and new call do not match that ice_address
+	minimal_test_ext().execute_with(|| {
+		let ice_address = samples::ACCOUNT_ID[1];
+		let icon_address_one = samples::ICON_ADDRESS[0];
+		let icon_address_two = samples::ICON_ADDRESS[1];
+		assert_ne!(icon_address_one, icon_address_two);
+
+		<IceIconMap<Test>>::insert(&ice_address, icon_address_one);
+
+		assert_noop!(
+			AirdropModule::insert_or_get_snapshot(
+				&icon_address_two,
+				&ice_address.encode().try_into().unwrap(),
+				false,
+				0u32.into()
+			),
+			PalletError::IconAddressInUse,
+		);
+	});
+
+	// There is previous record old this icon address
+	// and new call do not match that icon_address
+	minimal_test_ext().execute_with(|| {
+		let icon_address = samples::ICON_ADDRESS[1];
+		let ice_address_one = samples::ACCOUNT_ID[1];
+		let ice_address_two = samples::ACCOUNT_ID[2];
+		assert_ne!(ice_address_one, ice_address_two);
+
+		let snapshot = types::SnapshotInfo::<Test>::default().ice_address(ice_address_one.clone());
+		<IconSnapshotMap<Test>>::insert(&icon_address, snapshot);
+
+		assert_noop!(
+			AirdropModule::insert_or_get_snapshot(
+				&icon_address,
+				&ice_address_two.encode().try_into().unwrap(),
+				false,
+				0u32.into()
+			),
+			PalletError::IceAddressInUse,
+		);
+	});
+
+	// There is previous old record of both address
+	// and new call match that addresses
+	minimal_test_ext().execute_with(|| {
+		let icon_address = samples::ICON_ADDRESS[1];
+		let ice_address = samples::ACCOUNT_ID[1];
+
+		let snapshot = types::SnapshotInfo::<Test>::default().ice_address(ice_address.clone());
+		<IconSnapshotMap<Test>>::insert(&icon_address, snapshot.clone());
+		<IceIconMap<Test>>::insert(&ice_address, &icon_address);
+
+		let expected_snapshot = snapshot;
+		let call_result = AirdropModule::insert_or_get_snapshot(
+			&icon_address,
+			&ice_address.encode().try_into().unwrap(),
+			false,
+			0u32.into(),
+		);
+
+		assert_eq!(call_result.as_ref(), Ok(&expected_snapshot));
+		assert_eq!(
+			AirdropModule::get_icon_snapshot_map(&icon_address),
+			Some(expected_snapshot)
+		);
+		assert_eq!(
+			AirdropModule::get_ice_to_icon_map(&ice_address),
+			Some(icon_address)
+		);
+	});
+
+	// No previous record of both address
+	minimal_test_ext().execute_with(|| {
+		let icon_address = samples::ICON_ADDRESS[1];
+		let ice_address = samples::ACCOUNT_ID[1];
+
+		let expected_snapshot =
+			types::SnapshotInfo::<Test>::default().ice_address(ice_address.clone());
+		let call_result = AirdropModule::insert_or_get_snapshot(
+			&icon_address,
+			&ice_address.encode().try_into().unwrap(),
+			false,
+			0u32.into(),
+		);
+
+		assert_eq!(call_result.as_ref(), Ok(&expected_snapshot));
+		assert_eq!(
+			AirdropModule::get_icon_snapshot_map(&icon_address),
+			Some(expected_snapshot)
+		);
+		assert_eq!(
+			AirdropModule::get_ice_to_icon_map(&ice_address),
+			Some(icon_address)
+		);
+	});
+}

--- a/pallets/airdrop/src/types.rs
+++ b/pallets/airdrop/src/types.rs
@@ -1,0 +1,198 @@
+use crate as airdrop;
+use airdrop::pallet::Config;
+use airdrop::pallet::Error;
+use codec::MaxEncodedLen;
+use core::convert::Into;
+use frame_support::pallet_prelude::*;
+use frame_support::traits::Currency;
+use frame_system;
+use scale_info::TypeInfo;
+use serde::Deserialize;
+use sp_core::H160;
+use sp_runtime::traits::Convert;
+use sp_runtime::ArithmeticError;
+use sp_std::prelude::*;
+
+use frame_support::storage::bounded_vec::BoundedVec;
+
+/// AccountId of anything that implements frame_system::Config
+pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+
+///
+pub type VestingBalanceOf<T> =
+	<<T as pallet_vesting::Config>::Currency as Currency<AccountIdOf<T>>>::Balance;
+
+/// Type that represent the balance
+pub type BalanceOf<T> = <<T as Config>::Currency as Currency<AccountIdOf<T>>>::Balance;
+
+pub type ServerBalance = u128;
+
+pub fn to_balance<T: Config>(amount: ServerBalance) -> BalanceOf<T> {
+	<T::BalanceTypeConversion as Convert<ServerBalance, BalanceOf<T>>>::convert(amount)
+}
+
+pub fn from_balance<T: Config>(amount: BalanceOf<T>) -> ServerBalance {
+	<T::BalanceTypeConversion as Convert<BalanceOf<T>, ServerBalance>>::convert(amount)
+}
+
+/// Type that represent IconAddress
+pub type IconAddress = [u8; 20];
+
+pub type IceAddress = [u8; 32];
+
+pub type IceEvmAddress = H160;
+
+/// Type that represent Icon signed message
+pub type IconSignature = [u8; 65];
+
+//
+pub type IceSignature = [u8; 64];
+
+//
+pub type RawPayload = [u8; RAW_PAYLOAD_LENGTH];
+
+///
+pub type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
+
+pub type MerkleHash = [u8; 32];
+// pub type MerkleProofs=Vec<MerkleHash>;
+pub type MerkleProofs<T> = BoundedVec<MerkleHash, <T as Config>::MaxProofSize>;
+
+///
+pub type VestingInfoOf<T> = pallet_vesting::VestingInfo<VestingBalanceOf<T>, BlockNumberOf<T>>;
+
+/// type that represnt the error that can occur while validation the signature
+#[derive(Eq, PartialEq, Debug)]
+pub enum SignatureValidationError {
+	InvalidIconAddress,
+	InvalidIconSignature,
+	InvalidIceAddress,
+	Sha3Execution,
+}
+
+#[derive(Encode, Decode, Eq, PartialEq, Clone, TypeInfo, MaxEncodedLen)]
+#[scale_info(skip_type_params(T))]
+#[codec(mel_bound())]
+pub struct SnapshotInfo<T: Config> {
+	/// Icon address of this snapshot
+	pub ice_address: AccountIdOf<T>,
+
+	/// Total airdroppable-amount this icon_address hold
+	pub amount: BalanceOf<T>,
+
+	/// Indicator wather this icon_address holder is defi-user
+	pub defi_user: bool,
+
+	/// indicator wather the user have claimmed the balance
+	/// which will be given through instant transfer
+	pub done_instant: bool,
+
+	/// Indicator weather vesting schedult have been applied
+	/// to this user
+	pub done_vesting: bool,
+
+	// blocknumber that started vesting
+	pub vesting_block_number: Option<BlockNumberOf<T>>,
+
+	// block number when instant amount was given
+	pub instant_block_number: Option<BlockNumberOf<T>>,
+
+	pub initial_transfer: BalanceOf<T>,
+}
+
+impl<T: Config> core::fmt::Debug for SnapshotInfo<T> {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		f.debug_struct("SnapshotInfo")
+			.field("ice_address", &self.ice_address)
+			.field("amount", &self.amount)
+			.field("defi_user", &self.defi_user)
+			.field("done_instant", &self.done_instant)
+			.field("done_vesting", &self.done_vesting)
+			.field("vesting_block_number", &self.vesting_block_number)
+			.field("initial_transfer", &self.initial_transfer)
+			.field("instant_block_number", &self.instant_block_number)
+			.finish()
+	}
+}
+
+impl<T: Config> SnapshotInfo<T> {
+	pub fn new(ice_address: AccountIdOf<T>, defi_user: bool, amount: BalanceOf<T>) -> Self {
+		SnapshotInfo::<T> {
+			ice_address,
+			amount,
+			defi_user,
+			done_instant: false,
+			done_vesting: false,
+			vesting_block_number: None,
+			instant_block_number: None,
+			initial_transfer: 0u32.into(),
+		}
+	}
+}
+
+impl<T: Config> From<ArithmeticError> for Error<T> {
+	fn from(_: ArithmeticError) -> Self {
+		Error::<T>::ArithmeticError
+	}
+}
+
+impl<T: Config> From<SignatureValidationError> for Error<T> {
+	fn from(_: SignatureValidationError) -> Self {
+		Error::<T>::InvalidSignature
+	}
+}
+
+pub fn balance_to_u32<T: Config>(input: BalanceOf<T>) -> u32 {
+	TryInto::<u32>::try_into(input).ok().unwrap()
+}
+
+pub fn block_number_to_u32<T: Config>(input: BlockNumberOf<T>) -> u32 {
+	TryInto::<u32>::try_into(input).ok().unwrap()
+}
+/// Chain state
+#[derive(Deserialize, Encode, Decode, Clone, Eq, PartialEq, TypeInfo, MaxEncodedLen, Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
+pub struct AirdropState {
+	// Only receive claim request when this flag is true
+	pub block_claim_request: bool,
+
+	// Only receive exchange request when this flag is true
+	pub block_exchange_request: bool,
+}
+
+impl Default for AirdropState {
+	#[cfg(not(test))]
+	fn default() -> Self {
+		AirdropState {
+			block_claim_request: true,
+			block_exchange_request: true,
+		}
+	}
+
+	#[cfg(test)]
+	fn default() -> Self {
+		AirdropState {
+			block_claim_request: false,
+			block_exchange_request: false,
+		}
+	}
+}
+
+pub trait MerkelProofValidator<T: Config> {
+	fn validate(leaf_hash: MerkleHash, root_hash: MerkleHash, proofs: MerkleProofs<T>) -> bool;
+}
+
+/// Trait to commit behaviour of do_transfer function
+/// this trait now can me implmeneted according to
+/// the node behaviour eg: vesting manner and direct manner
+pub trait DoTransfer {
+	fn do_transfer<T: Config>(snapshot: &mut SnapshotInfo<T>) -> DispatchResult;
+}
+
+pub struct AirdropBehaviour {
+	pub defi_instant_percentage: u8,
+	pub non_defi_instant_percentage: u8,
+	pub vesting_period: u32,
+}
+
+pub const RAW_PAYLOAD_LENGTH: usize = b"icx_sendTransaction.data.{method.transfer.params.{wallet.b6e7a79d04e11a2dd43399f677878522523327cae2691b6cd1eb972b5a88eb48}}.dataType.call.from.hxb48f3bd3862d4a489fb3c9b761c4cfb20b34a645.nid.0x1.nonce.0x1.stepLimit.0x0.timestamp.0x0.to.hxb48f3bd3862d4a489fb3c9b761c4cfb20b34a645.version.0x3".len();

--- a/pallets/airdrop/src/utils.rs
+++ b/pallets/airdrop/src/utils.rs
@@ -1,0 +1,180 @@
+use crate as airdrop;
+use airdrop::types;
+use codec::alloc::string::String;
+use frame_support::pallet_prelude::*;
+use hex::FromHexError;
+use sp_core::H160;
+use sp_runtime::{
+	traits::{BlakeTwo256, Bounded, CheckedDiv, CheckedMul, CheckedSub, Convert, Saturating},
+	AccountId32, DispatchError,
+};
+use sp_std::vec::Vec;
+
+/// Reuturns an optional vesting schedule which when applied release given amount
+/// which will be complete in given block. If
+/// Also return amount which is remaineder if amount can't be perfectly divided
+/// in per block basis
+pub fn new_vesting_with_deadline<T, const VESTING_APPLICABLE_FROM: u32>(
+	amount: types::VestingBalanceOf<T>,
+	ends_in: types::BlockNumberOf<T>,
+) -> (Option<types::VestingInfoOf<T>>, types::VestingBalanceOf<T>)
+where
+	T: pallet_vesting::Config,
+{
+	const MIN_AMOUNT_PER_BLOCK: u32 = 1u32;
+
+	type BlockToBalance<T> = <T as pallet_vesting::Config>::BlockNumberToBalance;
+	let mut vesting = None;
+
+	let ends_in_as_balance = BlockToBalance::<T>::convert(ends_in);
+	let transfer_over = ends_in_as_balance.saturating_sub(VESTING_APPLICABLE_FROM.into());
+
+	let idol_transfer_multiple = transfer_over * MIN_AMOUNT_PER_BLOCK.into();
+
+	let remainding_amount = amount % idol_transfer_multiple;
+	let primary_transfer_amount = amount.saturating_sub(remainding_amount);
+
+	let per_block = primary_transfer_amount
+		.checked_div(&idol_transfer_multiple)
+		.unwrap_or_else(Bounded::min_value);
+
+	if per_block > Bounded::min_value() {
+		vesting = Some(types::VestingInfoOf::<T>::new(
+			primary_transfer_amount,
+			per_block,
+			VESTING_APPLICABLE_FROM.into(),
+		));
+	}
+
+	(vesting, remainding_amount)
+}
+
+pub fn get_instant_percentage<T: airdrop::Config>(is_defi_user: bool) -> u8 {
+	if is_defi_user {
+		T::AIRDROP_VARIABLES.defi_instant_percentage
+	} else {
+		T::AIRDROP_VARIABLES.non_defi_instant_percentage
+	}
+}
+
+pub fn get_splitted_amounts<T: airdrop::Config>(
+	total_amount: types::BalanceOf<T>,
+	instant_percentage: u8,
+) -> Result<(types::BalanceOf<T>, types::VestingBalanceOf<T>), DispatchError> {
+	let instant_amount = total_amount
+		.checked_mul(&instant_percentage.into())
+		.ok_or(sp_runtime::ArithmeticError::Overflow)?
+		.checked_div(&100_u32.into())
+		.ok_or(sp_runtime::ArithmeticError::Underflow)?;
+
+	let vesting_amount = total_amount
+		.checked_sub(&instant_amount)
+		.ok_or(sp_runtime::ArithmeticError::Underflow)?;
+
+	Ok(
+		(
+			instant_amount,
+			<T::BalanceTypeConversion as Convert<
+				types::BalanceOf<T>,
+				types::VestingBalanceOf<T>,
+			>>::convert(vesting_amount),
+		),
+	)
+}
+
+pub fn recover_address(
+	signature: &[u8],
+	payload: &[u8],
+) -> Result<Vec<u8>, types::SignatureValidationError> {
+	use fp_evm::LinearCostPrecompile;
+	use pallet_evm_precompile_sha3fips::Sha3FIPS256;
+	use pallet_evm_precompile_simple::ECRecoverPublicKey;
+	use types::SignatureValidationError;
+
+	const COST: u64 = 1;
+	const PADDING_FOR_V: [u8; 31] = [0; 31];
+
+	let (_exit_status, message_hash) =
+		Sha3FIPS256::execute(payload, COST).map_err(|_| SignatureValidationError::Sha3Execution)?;
+	let formatted_signature = {
+		let sig_r = &signature[..32];
+		let sig_s = &signature[32..64];
+		let sig_v = &signature[64..];
+
+		// Sig final is in the format of:
+		// object hash + 31 byte padding + 1 byte v + 32 byte r + 32 byte s
+		message_hash
+			.iter()
+			.chain(&PADDING_FOR_V)
+			.chain(sig_v)
+			.chain(sig_r)
+			.chain(sig_s)
+			.cloned()
+			.collect::<sp_std::vec::Vec<u8>>()
+	};
+
+	let (_exit_status, recovered_pub_key) = ECRecoverPublicKey::execute(&formatted_signature, COST)
+		.map_err(|_| SignatureValidationError::InvalidIconSignature)?;
+
+	let (_exit_status, computed_address) = Sha3FIPS256::execute(&recovered_pub_key, COST)
+		.map_err(|_| SignatureValidationError::Sha3Execution)?;
+	let address = computed_address[computed_address.len() - 20..].to_vec();
+
+	Ok(address)
+}
+
+pub fn into_account_id(address: H160) -> AccountId32 {
+	let mut data = [0u8; 24];
+	data[0..4].copy_from_slice(b"evm:");
+	data[4..24].copy_from_slice(&address[..]);
+	let hash = <BlakeTwo256 as sp_runtime::traits::Hash>::hash(&data);
+	AccountId32::from(Into::<[u8; 32]>::into(hash))
+}
+
+pub fn extract_ice_address(
+	payload: &[u8],
+	expected_address: &[u8],
+) -> Result<Vec<u8>, FromHexError> {
+	let expected_string = hex::encode(expected_address);
+	let expected_address = expected_string.as_bytes();
+	const PREFIX_LEN: usize = b"ice_sendTransaction.data.{method.transfer.params.{wallet.".len();
+	let address_len = expected_address.len();
+	let slice = payload[PREFIX_LEN..PREFIX_LEN + address_len].to_vec();
+	hex::decode(slice)
+}
+
+pub fn to_hex_string<T: Clone + Into<Vec<u8>>>(bytes: &T) -> String {
+	let vec: Vec<u8> = bytes.clone().into();
+	hex::encode(&vec)
+}
+
+pub fn hex_as_byte_array<const SIZE: usize>(hex_str: &str) -> Result<[u8; SIZE], FromHexError> {
+	let mut bytes = [0u8; SIZE];
+	hex::decode_to_slice(hex_str, &mut bytes as &mut [u8])?;
+	Ok(bytes)
+}
+
+pub fn wrap_bytes(payload: &[u8]) -> Vec<u8> {
+	let mut wrapped_message = "<Bytes>".as_bytes().to_vec();
+	wrapped_message.extend_from_slice(payload);
+	wrapped_message.extend_from_slice("</Bytes>".as_bytes());
+	wrapped_message
+}
+
+pub fn get_current_block_number<T: frame_system::Config>() -> types::BlockNumberOf<T> {
+	<frame_system::Pallet<T>>::block_number()
+}
+
+/// Struct that panics with given message
+/// This is intended to use as ValueQuery's OnEmpty holder
+pub struct PanicOnNoCreditor;
+impl<T> Get<T> for PanicOnNoCreditor {
+	fn get() -> T {
+		panic!(
+			"No creditor account configured.\
+		This call was expected to return default value,\
+		which will inturn produce undesired behaviour as\
+		using default AccountId as creditor is not unexpected"
+		);
+	}
+}

--- a/pallets/airdrop/src/vested_transfer.rs
+++ b/pallets/airdrop/src/vested_transfer.rs
@@ -1,0 +1,125 @@
+use crate as airdrop;
+use airdrop::{error, info};
+use airdrop::{types, utils, Pallet as AirdropModule};
+use frame_support::pallet_prelude::*;
+use frame_support::traits::{Currency, ExistenceRequirement};
+use sp_runtime::traits::{CheckedAdd, Convert};
+
+// TODO: put more relaible value
+pub const BLOCKS_IN_YEAR: u32 = 5_256_000u32;
+// Block number after which enable to do vesting
+pub const VESTING_APPLICABLE_FROM: u32 = 1u32;
+
+pub struct DoVestdTransfer;
+impl types::DoTransfer for DoVestdTransfer {
+	fn do_transfer<T: airdrop::Config>(snapshot: &mut types::SnapshotInfo<T>) -> DispatchResult {
+		let vesting_should_end_in = <T as airdrop::Config>::AIRDROP_VARIABLES.vesting_period;
+		let defi_user = snapshot.defi_user;
+		let total_amount = snapshot.amount;
+
+		let claimer = &snapshot.ice_address;
+		let creditor = AirdropModule::<T>::get_creditor_account()?;
+
+		let instant_percentage = utils::get_instant_percentage::<T>(defi_user);
+		let (mut instant_amount, vesting_amount) =
+			utils::get_splitted_amounts::<T>(total_amount, instant_percentage).map_err(|e |{
+				error!("At: get_splitted_amount. amount: {total_amount:?}. Instant percentage: {instant_percentage}. Reason: {e:?}");
+				e
+			})?;
+
+		let (transfer_shcedule, remainding_amount) = utils::new_vesting_with_deadline::<
+			T,
+			VESTING_APPLICABLE_FROM,
+		>(vesting_amount, vesting_should_end_in.into());
+
+		// Amount to be transferred is:
+		// x% of totoal amount
+		// + remainding amount which was not perfectly divisible
+		instant_amount = {
+			let remainding_amount = <T::BalanceTypeConversion as Convert<
+				types::VestingBalanceOf<T>,
+				types::BalanceOf<T>,
+			>>::convert(remainding_amount);
+
+			instant_amount
+				.checked_add(&remainding_amount)
+				.ok_or(sp_runtime::ArithmeticError::Overflow)?
+		};
+
+		let creditor_origin = <T as frame_system::Config>::Origin::from(
+			frame_system::RawOrigin::Signed(creditor.clone()),
+		);
+		let claimer_origin =
+			<T::Lookup as sp_runtime::traits::StaticLookup>::unlookup(claimer.clone());
+
+		match transfer_shcedule {
+			// Apply vesting
+			Some(schedule) if !snapshot.done_vesting => {
+				let vest_res = pallet_vesting::Pallet::<T>::vested_transfer(
+					creditor_origin,
+					claimer_origin,
+					schedule,
+				);
+
+				match vest_res {
+					// Everything went ok. update flag
+					Ok(()) => {
+						let block_number = utils::get_current_block_number::<T>();
+						snapshot.done_vesting = true;
+						snapshot.vesting_block_number = Some(block_number);
+
+						info!("Vesting applied for {claimer:?} at height {block_number:?}");
+					}
+					// log error
+					Err(err) => {
+						info!("Error while aplying vesting. For: {claimer:?}. Reason: {err:?}");
+					}
+				}
+			}
+
+			// Vesting was already done as snapshot.done_vesting is true
+			Some(_) => {
+				info!(
+					"Skipped vesting for: {claimer:?}. Reason: {reason}",
+					reason = "snapshot.done_vesting was already true"
+				);
+			}
+
+			// No schedule was created
+			None => {
+				// If vesting is not applicable once then with same total_amount
+				// it will not be applicable ever. So mark it as done.
+				snapshot.done_vesting = true;
+
+				info!("No schedule was created for: {claimer:?}. All amount transferred instantly");
+			}
+		}
+
+		// if not done previously
+		// Transfer the amount user is expected to receiver instantly
+		if !snapshot.done_instant {
+			<T as airdrop::Config>::Currency::transfer(
+				&creditor,
+				&claimer,
+				instant_amount,
+				ExistenceRequirement::KeepAlive,
+			)
+			.map_err(|err| {
+				info!("Failed to instant transfer. Claimer: {claimer:?}. Reason: {err:?}");
+				err
+			})?;
+
+			// Everything went ok. Update flag
+			snapshot.done_instant = true;
+			snapshot.initial_transfer = instant_amount;
+			snapshot.instant_block_number = Some(utils::get_current_block_number::<T>());
+		} else {
+			info!(
+				"skipped instant transfer for {claimer:?}. Reason: {reason}",
+				reason = "snapshot.done_instant was set to true already"
+			);
+		}
+
+		Ok(())
+	}
+}

--- a/pallets/airdrop/src/weights.rs
+++ b/pallets/airdrop/src/weights.rs
@@ -1,0 +1,85 @@
+use frame_support::{traits::Get, weights::Weight};
+use sp_std::marker::PhantomData;
+
+pub trait WeightInfo {
+	
+	fn set_airdrop_server_account() -> Weight;
+	fn dispatch_user_claim() -> Weight;
+	fn dispatch_exchange_claim() -> Weight;
+	fn update_airdrop_state() -> Weight;
+	fn change_merkle_root()->Weight;
+}
+
+/// Weight functions for `pallet_airdrop`.
+pub struct AirDropWeightInfo<T>(PhantomData<T>);
+
+impl<T: frame_system::Config> WeightInfo for AirDropWeightInfo<T>{
+	// Storage: Airdrop ServerAccount (r:1 w:1)
+	// Storage: System Number (r:1 w:0)
+	// Storage: System ExecutionPhase (r:1 w:0)
+	// Storage: System EventCount (r:1 w:1)
+	// Storage: System Events (r:1 w:1)
+	fn set_airdrop_server_account() -> Weight {
+		(20_566_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+	}
+	// Storage: Airdrop AirdropChainState (r:1 w:1)
+	// Storage: System Number (r:1 w:0)
+	// Storage: System ExecutionPhase (r:1 w:0)
+	// Storage: System EventCount (r:1 w:1)
+	// Storage: System Events (r:1 w:1)
+	fn update_airdrop_state() -> Weight {
+		(20_384_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+	}
+	// Storage: Airdrop AirdropChainState (r:1 w:0)
+	// Storage: Airdrop MerkleRoot (r:1 w:0)
+	// Storage: Airdrop IconSnapshotMap (r:1 w:1)
+	// Storage: Airdrop IceIconMap (r:1 w:1)
+	// Storage: Airdrop CreditorAccount (r:1 w:0)
+	// Storage: System Account (r:2 w:2)
+	// Storage: Vesting Vesting (r:1 w:1)
+	// Storage: System Number (r:1 w:0)
+	// Storage: System ExecutionPhase (r:1 w:0)
+	// Storage: System EventCount (r:1 w:1)
+	// Storage: System Events (r:1 w:1)
+	// Storage: Balances Locks (r:1 w:1)
+	fn dispatch_user_claim() -> Weight {
+		(246_184_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(13 as Weight))
+			.saturating_add(T::DbWeight::get().writes(8 as Weight))
+	}
+	// Storage: Airdrop AirdropChainState (r:1 w:0)
+	// Storage: Airdrop ExchangeAccountsMap (r:1 w:0)
+	// Storage: Airdrop MerkleRoot (r:1 w:0)
+	// Storage: Airdrop CreditorAccount (r:1 w:0)
+	// Storage: System Account (r:2 w:2)
+	// Storage: Airdrop IconSnapshotMap (r:1 w:1)
+	// Storage: Airdrop IceIconMap (r:1 w:1)
+	// Storage: Vesting Vesting (r:1 w:1)
+	// Storage: System Number (r:1 w:0)
+	// Storage: System ExecutionPhase (r:1 w:0)
+	// Storage: System EventCount (r:1 w:1)
+	// Storage: System Events (r:1 w:1)
+	// Storage: Balances Locks (r:1 w:1)
+	fn dispatch_exchange_claim() -> Weight {
+		(128_584_000 as Weight)
+			// Standard Error: 156_000
+			.saturating_add(392_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(14 as Weight))
+			.saturating_add(T::DbWeight::get().writes(8 as Weight))
+	}
+	// Storage: Airdrop MerkleRoot (r:1 w:1)
+	// Storage: System Number (r:1 w:0)
+	// Storage: System ExecutionPhase (r:1 w:0)
+	// Storage: System EventCount (r:1 w:1)
+	// Storage: System Events (r:1 w:1)
+	fn change_merkle_root() -> Weight {
+		(26_243_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+	}
+}
+

--- a/pallets/airdrop/test.sh
+++ b/pallets/airdrop/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cargo test && \
+cargo test --features no-vesting

--- a/runtime/arctic/Cargo.toml
+++ b/runtime/arctic/Cargo.toml
@@ -77,6 +77,7 @@ fp-self-contained = { default-features = false, git = "https://github.com/web3la
 # local pallet
 pallet-simple-inflation = { path = '../../pallets/simple-inflation', default-features = false, version = '0.0.2' }
 pallet-fees-split = { path = "../../pallets/fees-split", default-features = false, version = '0.0.1' }
+pallet-airdrop = { path = "../../pallets/airdrop", default-features = false }
 
 # ice-runtime-fees-split = { default-features = false, path = "../fees-split", optional=true}
 
@@ -172,6 +173,7 @@ std = [
 	"sp-version/std",
 
 	# "ice-runtime-fees-split",
+	"pallet-airdrop/std",
 
 	"frame-benchmarking/std",
 	# "frame-system-benchmarking/std",
@@ -206,7 +208,8 @@ runtime-benchmarks = [
 	"pallet-xcm/runtime-benchmarks",
 	"pallet-collective/runtime-benchmarks",
     "pallet-treasury/runtime-benchmarks",
-	"xcm-builder/runtime-benchmarks"
+	"xcm-builder/runtime-benchmarks",
+	"pallet-airdrop/runtime-benchmarks",
 ]
 
 try-runtime = [
@@ -223,4 +226,5 @@ try-runtime = [
     "pallet-timestamp/try-runtime",
     "pallet-transaction-payment/try-runtime",
     "pallet-vesting/try-runtime",
+	"pallet-airdrop/try-runtime",
 ]

--- a/runtime/arctic/src/lib.rs
+++ b/runtime/arctic/src/lib.rs
@@ -646,6 +646,23 @@ impl pallet_base_fee::Config for Runtime {
 
 impl pallet_randomness_collective_flip::Config for Runtime {}
 
+const VESTED_AIRDROP_BEHAVIOUR: pallet_airdrop::AirdropBehaviour =
+	pallet_airdrop::AirdropBehaviour {
+		defi_instant_percentage: 30,
+		non_defi_instant_percentage: 20,
+		vesting_period: 7776000,
+	};
+impl pallet_airdrop::Config for Runtime {
+	type Event = Event;
+	type Currency = Balances;
+	type BalanceTypeConversion = sp_runtime::traits::ConvertInto;
+	type AirdropWeightInfo = pallet_airdrop::weights::AirDropWeightInfo<Runtime>;
+	type MerkelProofValidator = pallet_airdrop::merkle::AirdropMerkleValidator<Runtime>;
+	type MaxProofSize = frame_support::traits::ConstU32<21>;
+	const AIRDROP_VARIABLES: pallet_airdrop::AirdropBehaviour = VESTED_AIRDROP_BEHAVIOUR;
+}
+
+
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
 	pub enum Runtime where
@@ -689,6 +706,7 @@ construct_runtime!(
 		Treasury: pallet_treasury::{Pallet, Call, Storage, Event<T>, Config},
 		SimpleInflation: pallet_simple_inflation::{Pallet, Call, Storage, Config<T>},
 		FeesSplit: pallet_fees_split::{Pallet, Call, Storage, Config<T>},
+		Airdrop: pallet_airdrop::{Pallet, Call, Storage, Config<T>, Event<T>},
 	}
 );
 

--- a/runtime/frost/Cargo.toml
+++ b/runtime/frost/Cargo.toml
@@ -79,6 +79,7 @@ fp-self-contained = {default-features = false, git = "https://github.com/web3lab
 # local pallet
 pallet-simple-inflation = { path = '../../pallets/simple-inflation', default-features = false, version = '0.0.2' }
 pallet-fees-split = { path = "../../pallets/fees-split", default-features = false, version = '0.0.1' }
+pallet-airdrop = { path = "../../pallets/airdrop", default-features = false }
 
 # ice-runtime-common = { default-features = false, path = "../common", optional = true }
 
@@ -138,6 +139,7 @@ std = [
 	"pallet-authorship/std",
 	"pallet-session/std",
 	"pallet-fees-split/std",
+	"pallet-airdrop/std",
 
 	"sp-api/std",
 	"sp-block-builder/std",
@@ -171,6 +173,7 @@ runtime-benchmarks = [
 	"pallet-vesting/runtime-benchmarks",
 	"pallet-collective/runtime-benchmarks",
     "pallet-treasury/runtime-benchmarks",
+	"pallet-airdrop/runtime-benchmarks",
 ]
 
 try-runtime = [
@@ -187,4 +190,5 @@ try-runtime = [
     "pallet-timestamp/try-runtime",
     "pallet-transaction-payment/try-runtime",
     "pallet-vesting/try-runtime",
+	"pallet-airdrop/try-runtime",
 ]

--- a/runtime/frost/src/lib.rs
+++ b/runtime/frost/src/lib.rs
@@ -537,6 +537,22 @@ impl pallet_simple_inflation::Config for Runtime {
 
 impl pallet_fees_split::Config for Runtime {}
 
+const VESTED_AIRDROP_BEHAVIOUR: pallet_airdrop::AirdropBehaviour =
+	pallet_airdrop::AirdropBehaviour {
+		defi_instant_percentage: 30,
+		non_defi_instant_percentage: 20,
+		vesting_period: 7776000,
+	};
+impl pallet_airdrop::Config for Runtime {
+	type Event = Event;
+	type Currency = Balances;
+	type BalanceTypeConversion = sp_runtime::traits::ConvertInto;
+	type AirdropWeightInfo = pallet_airdrop::weights::AirDropWeightInfo<Runtime>;
+	type MerkelProofValidator = pallet_airdrop::merkle::AirdropMerkleValidator<Runtime>;
+	type MaxProofSize = frame_support::traits::ConstU32<21>;
+	const AIRDROP_VARIABLES: pallet_airdrop::AirdropBehaviour = VESTED_AIRDROP_BEHAVIOUR;
+}
+
 frame_support::parameter_types! {
 	pub BoundDivision: U256 = U256::from(1024);
 }
@@ -600,6 +616,7 @@ construct_runtime!(
 		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
 		Authorship: pallet_authorship::{Pallet, Call, Storage, Inherent},
 		FeesSplit: pallet_fees_split::{Pallet, Call, Storage, Config<T>},
+		Airdrop: pallet_airdrop::{Pallet, Call, Storage, Config<T>, Event<T>},
 	}
 );
 


### PR DESCRIPTION
# Bring Airdrop pallet

## Expected behavior:
- Any eligible user should be able to claim tokens they are entitled to receive.
Here, eligible user means the list of public keys from which merkle root was calculated.
- All such claim request must pass through a server ( namely airdrop-server )
- On success of claim, `ServerAccount` is expected to get fee-refund
- Any claim request from outside server proxy should fail
- Exchange claim differs from normal claim in 2 ways: Signature validation is skipped & is only callable from sudo as root

## Note to operator
- Logs are added in various places for easy monitoring. Operator might wants to parse & redirect to files for better experience. Error like `CreditorOutOfFund` are expected to be rare but should be monitored critically
- `ServerAccount` & `CreditorAccount` is to be given maximum security possible especially `CreditorAccount`.


## Code structure
- Pallet is currently configured in both frost & arctic runtime and was tested on frost only
- Substrate related dependencies are same version as used in `runtime/`
- Tests and mock runtime are under `src/tests`
- Unlike most substrate pallet, mock runtime for airdrop was intended to be as close as possible to actual runtime
- Best effort was made to ensure standard substrate pallet format was followed

## Feature flags
### no-vesting
passing `no-vesting` compile time flags will disable vesting feature during airdrop claim process for both user & exchange accounts. However, flags like `done_vesting`, `vesting_block_number` will still be present in `Snapshot`

## Finishing up
- Need to update actual Merle root of claimers
- Need to update actual server_account
- Put actual funded creditor account