### PR TITLE
Gas to weight real mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "arctic-runtime"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "frost-runtime"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "fp-rpc",
  "fp-self-contained",

--- a/runtime/arctic/Cargo.toml
+++ b/runtime/arctic/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://substrate.dev'
 license = 'Apache-2.0'
 name = 'arctic-runtime'
 repository = 'https://github.com/web3labs/ice-substrate/'
-version = '0.4.35'
+version = '0.4.36'
 publish = false
 
 [package.metadata.docs.rs]

--- a/runtime/arctic/src/lib.rs
+++ b/runtime/arctic/src/lib.rs
@@ -457,7 +457,7 @@ pub const GAS_PER_SECOND: u64 = 40_000_000;
 pub const WEIGHT_PER_GAS: u64 = WEIGHT_PER_SECOND / GAS_PER_SECOND;
 
 parameter_types! {
-	pub const ChainId: u64 = 42;
+	pub const ChainId: u64 = 552;
 	pub BlockGasLimit: U256 = U256::from(NORMAL_DISPATCH_RATIO * 2 * WEIGHT_PER_SECOND / WEIGHT_PER_GAS);
 	pub PrecompilesValue: FrontierPrecompiles<Runtime> = FrontierPrecompiles::<_>::new();
 }
@@ -566,14 +566,14 @@ parameter_types! {
 
 type TechnicalCollective = pallet_collective::Instance2;
 impl pallet_collective::Config<TechnicalCollective> for Runtime {
-    type Origin = Origin;
-    type Proposal = Call;
-    type Event = Event;
-    type MotionDuration = TechnicalMotionDuration;
-    type MaxProposals = TechnicalMaxProposals;
-    type MaxMembers = TechnicalMaxMembers;
-    type DefaultVote = pallet_collective::PrimeDefaultVote;
-    type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
+	type Origin = Origin;
+	type Proposal = Call;
+	type Event = Event;
+	type MotionDuration = TechnicalMotionDuration;
+	type MaxProposals = TechnicalMaxProposals;
+	type MaxMembers = TechnicalMaxMembers;
+	type DefaultVote = pallet_collective::PrimeDefaultVote;
+	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
 }
 
 parameter_types! {

--- a/runtime/arctic/src/lib.rs
+++ b/runtime/arctic/src/lib.rs
@@ -452,15 +452,29 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
 	}
 }
 
+//https://github.com/AstarNetwork/Astar/blob/master/runtime/astar/src/lib.rs#L658
+pub const GAS_PER_SECOND: u64 = 40_000_000;
+pub const WEIGHT_PER_GAS: u64 = WEIGHT_PER_SECOND / GAS_PER_SECOND;
+
 parameter_types! {
-	pub const ChainId: u64 = 552;
-	pub BlockGasLimit: U256 = U256::from(u32::max_value());
+	pub const ChainId: u64 = 42;
+	pub BlockGasLimit: U256 = U256::from(NORMAL_DISPATCH_RATIO * 2 * WEIGHT_PER_SECOND / WEIGHT_PER_GAS);
 	pub PrecompilesValue: FrontierPrecompiles<Runtime> = FrontierPrecompiles::<_>::new();
+}
+
+pub struct LocalGasWeightMapping;
+impl pallet_evm::GasWeightMapping for LocalGasWeightMapping {
+	fn gas_to_weight(gas: u64) -> Weight {
+		gas.saturating_mul(WEIGHT_PER_GAS)
+	}
+	fn weight_to_gas(weight: Weight) -> u64 {
+		u64::try_from(weight.wrapping_div(WEIGHT_PER_GAS)).unwrap_or(u32::MAX as u64)
+	}
 }
 
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = BaseFee;
-	type GasWeightMapping = ();
+	type GasWeightMapping = LocalGasWeightMapping;
 	type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
 	type CallOrigin = EnsureAddressTruncated;
 	type WithdrawOrigin = EnsureAddressTruncated;

--- a/runtime/frost/Cargo.toml
+++ b/runtime/frost/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://substrate.dev'
 license = 'Apache-2.0'
 name = 'frost-runtime'
 repository = 'https://github.com/web3labs/ice-substrate/'
-version = '0.4.35'
+version = '0.4.36'
 publish = false
 
 [package.metadata.docs.rs]

--- a/runtime/frost/src/lib.rs
+++ b/runtime/frost/src/lib.rs
@@ -137,10 +137,6 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	state_version: 1,
 };
 
-pub const MILLISECS_PER_BLOCK: u64 = 6000;
-
-pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
-
 // Prints debug output of the `contracts` pallet to stdout if the node is
 // started with `-lruntime::contracts=debug`.
 const CONTRACTS_DEBUG_OUTPUT: bool = true;
@@ -397,15 +393,29 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
 	}
 }
 
+//https://github.com/AstarNetwork/Astar/blob/master/runtime/astar/src/lib.rs#L658
+pub const GAS_PER_SECOND: u64 = 40_000_000;
+pub const WEIGHT_PER_GAS: u64 = WEIGHT_PER_SECOND / GAS_PER_SECOND;
+
 parameter_types! {
 	pub const ChainId: u64 = 42;
-	pub BlockGasLimit: U256 = U256::from(u32::max_value());
+	pub BlockGasLimit: U256 = U256::from(NORMAL_DISPATCH_RATIO * 2 * WEIGHT_PER_SECOND / WEIGHT_PER_GAS);
 	pub PrecompilesValue: FrontierPrecompiles<Runtime> = FrontierPrecompiles::<_>::new();
+}
+
+pub struct LocalGasWeightMapping;
+impl pallet_evm::GasWeightMapping for LocalGasWeightMapping {
+	fn gas_to_weight(gas: u64) -> Weight {
+		gas.saturating_mul(WEIGHT_PER_GAS)
+	}
+	fn weight_to_gas(weight: Weight) -> u64 {
+		u64::try_from(weight.wrapping_div(WEIGHT_PER_GAS)).unwrap_or(u32::MAX as u64)
+	}
 }
 
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = BaseFee;
-	type GasWeightMapping = ();
+	type GasWeightMapping = LocalGasWeightMapping;
 	type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
 	type CallOrigin = EnsureAddressTruncated;
 	type WithdrawOrigin = EnsureAddressTruncated;


### PR DESCRIPTION
This PR: sets the real gas to weight mapping (previously 1:1) AND sets the real gas per block limit (previously hardcoded u32::MAX).


This is a short benchmark to demonstrate that even though it is a little expensive than it should be, is a good starting point (before this PR, any evm Execution costed barely more than BaseExtrensicFee, since gas cost is little, and translated 1:1 to weight was more or less 0).

```
WEIGHT PER SECOND: 1_000_000_000_000
WEIGHT PER BLOCK: 2_000_000_000_000
FEE PER BLOCK: 23.31 ICY
```

This is the real cost for deploying the migration solidity contract:

```
DEPLOY WEIGHT: 6,253,550,000
DEPLOY FEE: 0.2 ICY
```

Which represent:

```
2_000_000_000_000 / 6,253,550,000 = 319
23.31 / 0.2 = 116

1 / 319 * 100 = 0.31% of block time
1 / 116 * 100 = 0.86% of Fees
```

Conclusion:
```
deploy is a little expensive ~ 3x reality weight
```


Set migration simple tx with storage set:

```
TX WEIGHT: 1,147,825,000
TX FEE: 0.05 ICY
```

```
2_000_000_000_000 / 1,147,825,000 = 1742
23.31 / 0.05 = 466

0.05% of block time
0.21% of Fees
```

```
tx is a little expensive ~ 4x reality weight
```