### PR TITLE
Set default ss58 prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "ice-node"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "arctic-runtime",
  "async-trait",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://substrate.dev'
 license = 'Apache-2.0'
 name = 'ice-node'
 repository = 'https://github.com/web3labs/ice-substrate'
-version = '0.4.40'
+version = '0.4.41'
 publish = false
 
 [package.metadata.docs.rs]

--- a/node/src/chain_spec/arctic.rs
+++ b/node/src/chain_spec/arctic.rs
@@ -3,8 +3,9 @@ use arctic_runtime::currency::ICY;
 use arctic_runtime::{
 	wasm_binary_unwrap, AccountId, AirdropConfig, AuraConfig, AuraId, BalancesConfig,
 	CollatorSelectionConfig, CouncilConfig, CouncilMembershipConfig, DemocracyConfig, EVMConfig,
-	GenesisConfig, IndicesConfig, ParachainInfoConfig, SessionConfig, SessionKeys, Signature,
-	SudoConfig, SystemConfig, TechnicalCommitteeConfig, TechnicalMembershipConfig, VestingConfig,
+	GenesisConfig, IndicesConfig, ParachainInfoConfig, SS58Prefix, SessionConfig, SessionKeys,
+	Signature, SudoConfig, SystemConfig, TechnicalCommitteeConfig, TechnicalMembershipConfig,
+	VestingConfig,
 };
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
@@ -27,7 +28,7 @@ fn arctic_properties() -> Properties {
 
 	properties.insert("tokenSymbol".into(), "ICY".into());
 	properties.insert("tokenDecimals".into(), 18.into());
-	properties.insert("ss58Format".into(), 15253.into());
+	properties.insert("ss58Format".into(), SS58Prefix::get().into());
 
 	properties
 }

--- a/node/src/chain_spec/frost.rs
+++ b/node/src/chain_spec/frost.rs
@@ -3,7 +3,7 @@
 use frost_runtime::{
 	currency::ICY, opaque::SessionKeys, AccountId, AirdropConfig, AuraConfig, BalancesConfig,
 	CouncilConfig, CouncilMembershipConfig, DemocracyConfig, EVMConfig, EthereumConfig,
-	GenesisConfig, GrandpaConfig, IndicesConfig, SessionConfig, Signature, SudoConfig,
+	GenesisConfig, GrandpaConfig, IndicesConfig, SS58Prefix, SessionConfig, Signature, SudoConfig,
 	SystemConfig, TechnicalCommitteeConfig, TechnicalMembershipConfig, TreasuryPalletId,
 	WASM_BINARY,
 };
@@ -31,7 +31,7 @@ fn frost_properties() -> Properties {
 
 	properties.insert("tokenSymbol".into(), "ICY".into());
 	properties.insert("tokenDecimals".into(), 18.into());
-	properties.insert("ss58Format".into(), 15253.into());
+	properties.insert("ss58Format".into(), SS58Prefix::get().into());
 
 	properties
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -160,6 +160,9 @@ fn extract_genesis_wasm(chain_spec: &Box<dyn sc_service::ChainSpec>) -> Result<V
 pub fn run() -> Result<()> {
 	let cli = Cli::from_args();
 
+	//TODO: figure out a way to set this without hardcoding
+	sp_core::crypto::set_default_ss58_version(sp_core::crypto::Ss58AddressFormat::custom(15253));
+
 	match &cli.subcommand {
 		Some(Subcommand::BuildSpec(cmd)) => {
 			let runner = cli.create_runner(cmd)?;


### PR DESCRIPTION
This is a fix. Prior to this, after adding the new ss58 prefix, transactions were failing in PolkadotJS.