### PR TITLE
Max code len to contracts pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "arctic-runtime"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -3064,7 +3064,7 @@ dependencies = [
 
 [[package]]
 name = "frost-runtime"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "fp-rpc",
  "fp-self-contained",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "ice-node"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "arctic-runtime",
  "async-trait",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://substrate.dev'
 license = 'Apache-2.0'
 name = 'ice-node'
 repository = 'https://github.com/web3labs/ice-substrate'
-version = '0.4.41'
+version = '0.4.42'
 publish = false
 
 [package.metadata.docs.rs]

--- a/runtime/arctic/Cargo.toml
+++ b/runtime/arctic/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://substrate.dev'
 license = 'Apache-2.0'
 name = 'arctic-runtime'
 repository = 'https://github.com/web3labs/ice-substrate/'
-version = '0.4.40'
+version = '0.4.41'
 publish = false
 
 [package.metadata.docs.rs]

--- a/runtime/arctic/src/lib.rs
+++ b/runtime/arctic/src/lib.rs
@@ -1,7 +1,6 @@
 //! The Substrate Node Template runtime. This can be compiled with `#[no_std]`, ready for Wasm.
 #![allow(clippy::identity_op)]
 #![allow(clippy::unnecessary_cast)]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
@@ -25,6 +24,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use pallet_evm::FeeCalculator;
 
 use frame_support::{
+	pallet_prelude::ConstU32,
 	traits::{EnsureOneOf, EqualPrivilegeOnly, InstanceFilter, LockIdentifier},
 	RuntimeDebug,
 };
@@ -384,9 +384,9 @@ impl pallet_contracts::Config for Runtime {
 	type DeletionQueueDepth = DeletionQueueDepth;
 	type DeletionWeightLimit = DeletionWeightLimit;
 	type Schedule = Schedule;
-	type ContractAccessWeight = ();
-	type MaxCodeLen = ();
-	type RelaxedMaxCodeLen = ();
+	type ContractAccessWeight = pallet_contracts::DefaultContractAccessWeight<RuntimeBlockWeights>;
+	type MaxCodeLen = ConstU32<{ 128 * 1024 }>;
+	type RelaxedMaxCodeLen = ConstU32<{ 256 * 1024 }>;
 	type CallStack = [pallet_contracts::Frame<Self>; 31];
 	type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
 }

--- a/runtime/frost/Cargo.toml
+++ b/runtime/frost/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://substrate.dev'
 license = 'Apache-2.0'
 name = 'frost-runtime'
 repository = 'https://github.com/web3labs/ice-substrate/'
-version = '0.4.40'
+version = '0.4.41'
 publish = false
 
 [package.metadata.docs.rs]

--- a/runtime/frost/src/lib.rs
+++ b/runtime/frost/src/lib.rs
@@ -1,7 +1,6 @@
 //! The Substrate Node Template runtime. This can be compiled with `#[no_std]`, ready for Wasm.
 #![allow(clippy::identity_op)]
 #![allow(clippy::unnecessary_cast)]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
@@ -315,9 +314,9 @@ impl pallet_contracts::Config for Runtime {
 	type DeletionQueueDepth = DeletionQueueDepth;
 	type DeletionWeightLimit = DeletionWeightLimit;
 	type Schedule = Schedule;
-	type ContractAccessWeight = ();
-	type MaxCodeLen = ();
-	type RelaxedMaxCodeLen = ();
+	type ContractAccessWeight = pallet_contracts::DefaultContractAccessWeight<RuntimeBlockWeights>;
+	type MaxCodeLen = ConstU32<{ 128 * 1024 }>;
+	type RelaxedMaxCodeLen = ConstU32<{ 256 * 1024 }>;
 	type CallStack = [pallet_contracts::Frame<Self>; 31];
 	type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
 }


### PR DESCRIPTION
Before this PR, I could not deploy any Ink contract on my running local node. Even tried with a contract of size 0.8kb and got "CodeTooLarge" error. This PR fixes this.