### PR TITLE
Fix build for try-runtime feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "ice-node"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "arctic-runtime",
  "async-trait",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://substrate.dev'
 license = 'Apache-2.0'
 name = 'ice-node'
 repository = 'https://github.com/web3labs/ice-substrate'
-version = '0.4.42'
+version = '0.4.43'
 publish = false
 
 [package.metadata.docs.rs]
@@ -145,14 +145,15 @@ build-script-utils = { package = "substrate-build-script-utils", git = "https://
 
 [features]
 default = [
+    "cli",
     "aura",
-    "sc-cli",
-    "polkadot-cli",
     "sc-service",
     "sc-service/db",
 ]
 
 cli = [
+    'sc-cli',
+    'polkadot-cli',
     'try-runtime-cli',
 ]
 


### PR DESCRIPTION
Try-runtime is a set of hooks that can be used to test storage migrations.

In order to test a migration one would have to:
- Have a node setup up and running
- The storage migration changes available in on_runtime_upgrade hook
- The pre_upgrade and post_upgrade hooks implemented
- Increase the chain spec version
- Run ```cargo run --release --features=try-runtime try-runtime on-runtime-upgrade live --uri ws://localhost:9944``` (with the real uri)

The pre_ and post_ are not meant to be used directly on the prod node, since failing the migration will terminate the node process. Instead, the hooks can be ran using the CLI above.

Certain Cargo.toml files must be modified in order to enable try-runtime feature for a new pallet, but only when needed, no pre-configuration must be done prior to that.