### PR TITLE
Feat: Tech Committee can Add new members

### DIFF
--- a/runtime/arctic/src/lib.rs
+++ b/runtime/arctic/src/lib.rs
@@ -976,11 +976,11 @@ impl pallet_membership::Config<pallet_membership::Instance1> for Runtime {
 
 impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type AddOrigin = MoreThanHalfCouncil;
-	type RemoveOrigin = MoreThanHalfCouncil;
-	type SwapOrigin = MoreThanHalfCouncil;
-	type ResetOrigin = MoreThanHalfCouncil;
-	type PrimeOrigin = MoreThanHalfCouncil;
+	type AddOrigin = EnsureRootOrAllTechnicalCommittee;
+	type RemoveOrigin = EnsureRootOrAllTechnicalCommittee;
+	type SwapOrigin = EnsureRootOrAllTechnicalCommittee;
+	type ResetOrigin = EnsureRootOrAllTechnicalCommittee;
+	type PrimeOrigin = EnsureRootOrAllTechnicalCommittee;
 	type MembershipInitialized = TechnicalCommittee;
 	type MembershipChanged = TechnicalCommittee;
 	type MaxMembers = TechnicalMaxMembers;

--- a/runtime/arctic/src/lib.rs
+++ b/runtime/arctic/src/lib.rs
@@ -976,11 +976,11 @@ impl pallet_membership::Config<pallet_membership::Instance1> for Runtime {
 
 impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type AddOrigin = EnsureRootOrAllTechnicalCommittee;
-	type RemoveOrigin = EnsureRootOrAllTechnicalCommittee;
-	type SwapOrigin = EnsureRootOrAllTechnicalCommittee;
-	type ResetOrigin = EnsureRootOrAllTechnicalCommittee;
-	type PrimeOrigin = EnsureRootOrAllTechnicalCommittee;
+	type AddOrigin = EitherOfDiverse<MoreThanHalfCouncil, EnsureRootOrAllTechnicalCommittee>;
+	type RemoveOrigin = MoreThanHalfCouncil;
+	type SwapOrigin = MoreThanHalfCouncil;
+	type ResetOrigin = MoreThanHalfCouncil;
+	type PrimeOrigin = EitherOfDiverse<MoreThanHalfCouncil, EnsureRootOrAllTechnicalCommittee>;
 	type MembershipInitialized = TechnicalCommittee;
 	type MembershipChanged = TechnicalCommittee;
 	type MaxMembers = TechnicalMaxMembers;

--- a/runtime/frost/src/lib.rs
+++ b/runtime/frost/src/lib.rs
@@ -898,11 +898,11 @@ impl pallet_membership::Config<pallet_membership::Instance1> for Runtime {
 
 impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type AddOrigin = EnsureRootOrAllTechnicalCommittee;
-	type RemoveOrigin = EnsureRootOrAllTechnicalCommittee;
-	type SwapOrigin = EnsureRootOrAllTechnicalCommittee;
-	type ResetOrigin = EnsureRootOrAllTechnicalCommittee;
-	type PrimeOrigin = EnsureRootOrAllTechnicalCommittee;
+	type AddOrigin = EitherOfDiverse<MoreThanHalfCouncil, EnsureRootOrAllTechnicalCommittee>;
+	type RemoveOrigin = MoreThanHalfCouncil;
+	type SwapOrigin = MoreThanHalfCouncil;
+	type ResetOrigin = MoreThanHalfCouncil;
+	type PrimeOrigin = EitherOfDiverse<MoreThanHalfCouncil, EnsureRootOrAllTechnicalCommittee>;
 	type MembershipInitialized = TechnicalCommittee;
 	type MembershipChanged = TechnicalCommittee;
 	type MaxMembers = TechnicalMaxMembers;

--- a/runtime/frost/src/lib.rs
+++ b/runtime/frost/src/lib.rs
@@ -898,11 +898,11 @@ impl pallet_membership::Config<pallet_membership::Instance1> for Runtime {
 
 impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type AddOrigin = MoreThanHalfCouncil;
-	type RemoveOrigin = MoreThanHalfCouncil;
-	type SwapOrigin = MoreThanHalfCouncil;
-	type ResetOrigin = MoreThanHalfCouncil;
-	type PrimeOrigin = MoreThanHalfCouncil;
+	type AddOrigin = EnsureRootOrAllTechnicalCommittee;
+	type RemoveOrigin = EnsureRootOrAllTechnicalCommittee;
+	type SwapOrigin = EnsureRootOrAllTechnicalCommittee;
+	type ResetOrigin = EnsureRootOrAllTechnicalCommittee;
+	type PrimeOrigin = EnsureRootOrAllTechnicalCommittee;
 	type MembershipInitialized = TechnicalCommittee;
 	type MembershipChanged = TechnicalCommittee;
 	type MaxMembers = TechnicalMaxMembers;

--- a/runtime/snow/src/lib.rs
+++ b/runtime/snow/src/lib.rs
@@ -957,11 +957,11 @@ impl pallet_membership::Config<pallet_membership::Instance1> for Runtime {
 
 impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type AddOrigin = MoreThanHalfCouncil;
-	type RemoveOrigin = MoreThanHalfCouncil;
-	type SwapOrigin = MoreThanHalfCouncil;
-	type ResetOrigin = MoreThanHalfCouncil;
-	type PrimeOrigin = MoreThanHalfCouncil;
+	type AddOrigin = EnsureRootOrAllTechnicalCommittee;
+	type RemoveOrigin = EnsureRootOrAllTechnicalCommittee;
+	type SwapOrigin = EnsureRootOrAllTechnicalCommittee;
+	type ResetOrigin = EnsureRootOrAllTechnicalCommittee;
+	type PrimeOrigin = EnsureRootOrAllTechnicalCommittee;
 	type MembershipInitialized = TechnicalCommittee;
 	type MembershipChanged = TechnicalCommittee;
 	type MaxMembers = TechnicalMaxMembers;

--- a/runtime/snow/src/lib.rs
+++ b/runtime/snow/src/lib.rs
@@ -957,11 +957,11 @@ impl pallet_membership::Config<pallet_membership::Instance1> for Runtime {
 
 impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type AddOrigin = EnsureRootOrAllTechnicalCommittee;
-	type RemoveOrigin = EnsureRootOrAllTechnicalCommittee;
-	type SwapOrigin = EnsureRootOrAllTechnicalCommittee;
-	type ResetOrigin = EnsureRootOrAllTechnicalCommittee;
-	type PrimeOrigin = EnsureRootOrAllTechnicalCommittee;
+	type AddOrigin = EitherOfDiverse<MoreThanHalfCouncil, EnsureRootOrAllTechnicalCommittee>;
+	type RemoveOrigin = MoreThanHalfCouncil;
+	type SwapOrigin = MoreThanHalfCouncil;
+	type ResetOrigin = MoreThanHalfCouncil;
+	type PrimeOrigin = EitherOfDiverse<MoreThanHalfCouncil, EnsureRootOrAllTechnicalCommittee>;
 	type MembershipInitialized = TechnicalCommittee;
 	type MembershipChanged = TechnicalCommittee;
 	type MaxMembers = TechnicalMaxMembers;


### PR DESCRIPTION
Previously we tried to add new members on Tech Committee which resulted in "Bad Origin" since it was configured to be possible only via council. This will allow adding of new members and selecting prime-member  on Tech Committee from following 2 criteria:

- Either half of council approves of motion
- Or All Tech Committee Members approve of Proposal
